### PR TITLE
Fixed error message for duplicate typeIds

### DIFF
--- a/lib/src/registry/type_registry_impl.dart
+++ b/lib/src/registry/type_registry_impl.dart
@@ -37,7 +37,7 @@ class TypeRegistryImpl implements TypeRegistry {
       typeId = typeId + reservedTypeIds;
 
       if (findAdapterForTypeId(typeId) != null) {
-        throw HiveError('There is already a TypeAdapter for typeId $typeId.');
+        throw HiveError('There is already a TypeAdapter for typeId ${typeId - reservedTypeIds}.');
       }
     }
 


### PR DESCRIPTION
I was getting the error ```There is already a TypeAdapter for typeId 58``` when in reality I should have been getting the error ```There is already a TypeAdapter for typeId 26```. 

This PR makes sure the error developers see is accurate and uses the correct typeId, by taking the reserved type ids into account.