### PR TITLE
Fixed the web support by checking for web platform before using dart:io

### DIFF
--- a/lib/src/backend/vm/backend_manager.dart
+++ b/lib/src/backend/vm/backend_manager.dart
@@ -5,8 +5,11 @@ import 'package:hive/src/backend/storage_backend.dart';
 import 'package:hive/src/backend/vm/storage_backend_vm.dart';
 import 'package:meta/meta.dart';
 
+// From: https://api.flutter.dev/flutter/foundation/kIsWeb-constant.html
+const bool kIsWeb = identical(0, 0.0);
+
 class BackendManager implements BackendManagerInterface {
-  final delimiter = Platform.isWindows ? '\\' : '/';
+  final delimiter = (kIsWeb || !Platform.isWindows) ? '/' : '\\';
 
   @override
   Future<StorageBackend> open(


### PR DESCRIPTION
Calling the dart:io function `Platform.isWindows` before checking for web results in a crash, because dart:io is not supported on the web.
See: https://api.flutter.dev/flutter/dart-io/dart-io-library.html

> **Important:** Browser-based applications can't use this library. Only servers, command-line scripts, and Flutter mobile apps can import and use dart:io.

Alternatively, you could revert commit [d932473c09ed6cce16a38cce59a92843d83e0e4d](https://github.com/hivedb/hive/commit/d932473c09ed6cce16a38cce59a92843d83e0e4d) that dropped path dependency.