### PR TITLE
add hash code and == operator overrides to TypeAdapterGenerator

### DIFF
--- a/hive_generator/lib/src/type_adapter_generator.dart
+++ b/hive_generator/lib/src/type_adapter_generator.dart
@@ -42,6 +42,16 @@ class TypeAdapterGenerator extends GeneratorForAnnotation<HiveType> {
       void write(BinaryWriter writer, ${cls.name} obj) {
         ${builder.buildWrite()}
       }
+
+      @override
+      int get hashCode => typeId.hashCode;
+
+      @override
+      bool operator ==(Object other) =>
+          identical(this, other) ||
+          other is $adapterName &&
+              runtimeType == other.runtimeType &&
+              typeId == other.typeId;
     }
     ''';
   }


### PR DESCRIPTION
Fixes #226. Tested using the forked repository as dependency in pubspec.yaml. Not sure how to use flutter test to see if generated TypeAdapters are comparable.