### PR TITLE
Adds boxExists method to Hive

### DIFF
--- a/hive/lib/src/backend/js/backend_manager.dart
+++ b/hive/lib/src/backend/js/backend_manager.dart
@@ -25,4 +25,15 @@ class BackendManager implements BackendManagerInterface {
   Future<void> deleteBox(String name, String path) {
     return window.indexedDB.deleteDatabase(name);
   }
+
+  @override
+  Future<bool> boxExists(String name, String path) async {
+    // https://stackoverflow.com/a/17473952
+    var _exists = true;
+    await window.indexedDB.open(name, onUpgradeNeeded: (e) {
+      e.target.transaction.abort();
+      _exists = false;
+    });
+    return _exists;
+  }
 }

--- a/hive/lib/src/backend/storage_backend.dart
+++ b/hive/lib/src/backend/storage_backend.dart
@@ -44,4 +44,7 @@ abstract class BackendManagerInterface {
 
   /// Deletes database
   Future<void> deleteBox(String name, String path);
+
+  /// Checks if box exists
+  Future<bool> boxExists(String name, String path);
 }

--- a/hive/lib/src/backend/stub/backend_manager.dart
+++ b/hive/lib/src/backend/stub/backend_manager.dart
@@ -13,4 +13,9 @@ class BackendManager implements BackendManagerInterface {
   Future<void> deleteBox(String name, String path) {
     throw UnimplementedError();
   }
+
+  @override
+  Future<bool> boxExists(String name, String path) {
+    throw UnimplementedError();
+  }
 }

--- a/hive/lib/src/backend/vm/backend_manager.dart
+++ b/hive/lib/src/backend/vm/backend_manager.dart
@@ -61,4 +61,11 @@ class BackendManager implements BackendManagerInterface {
       await file.delete();
     }
   }
+
+  @override
+  Future<bool> boxExists(String name, String path) async {
+    return await File('$path$_delimiter$name.hive').exists() ||
+        await File('$path$_delimiter$name.hivec').exists() ||
+        await File('$path$_delimiter$name.lock').exists();
+  }
 }

--- a/hive/lib/src/hive.dart
+++ b/hive/lib/src/hive.dart
@@ -60,6 +60,9 @@ abstract class HiveInterface implements TypeRegistry {
 
   /// Generates a secure encryption key using the fortuna random algorithm.
   List<int> generateSecureKey();
+
+  /// Checks if a box exists
+  Future<bool> boxExists(String name);
 }
 
 ///

--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -203,4 +203,10 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
   List<int> generateSecureKey() {
     return _secureRandom.nextBytes(32);
   }
+
+  @override
+  Future<bool> boxExists(String name, {String path}) async {
+    var lowerCaseName = name.toLowerCase();
+    return await _manager.boxExists(lowerCaseName, path ?? homePath);
+  }
 }

--- a/hive/test/tests/hive_impl_test.dart
+++ b/hive/test/tests/hive_impl_test.dart
@@ -249,5 +249,28 @@ void main() {
 
       await hive.close();
     });
+
+    group('.boxExists()', () {
+      test('returns true if a box was created', () async {
+        var hive = await initHive();
+        await hive.openBox('testBox1');
+        expect(await hive.boxExists('testBox1'), true);
+        await hive.close();
+      });
+
+      test('returns false if no box was created', () async {
+        var hive = await initHive();
+        expect(await hive.boxExists('testBox1'), false);
+        await hive.close();
+      });
+
+      test('returns false if box was created and then deleted', () async {
+        var hive = await initHive();
+        await hive.openBox('testBox1');
+        await hive.deleteBoxFromDisk('testBox1');
+        expect(await hive.boxExists('testBox1'), false);
+        await hive.close();
+      });
+    });
   });
 }


### PR DESCRIPTION
Adding a method to check if a box exists given its `name` and an optional `path`. This method is useful in case of migrations where you want to proceed only if a certain box exists.