### PR TITLE
Ease up path dependency

### DIFF
--- a/hive_flutter/pubspec.yaml
+++ b/hive_flutter/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 
   hive: ">=1.0.0 <2.0.0"
   path_provider: ">=1.0.0 <2.0.0"
-  path: ">=1.6.0 <1.7.0"
+  path: ">=1.6.0 <2.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
`path` 1.7.0 was released on 13.04.2020 and new versions of `flutter` [1.18.0-6.0.pre.99 in my case] depend on 1.7.0.

So the current version restriction is the blocker for everyone naive enough to run `flutter upgrade` these days:

```
Because every version of flutter_test from sdk depends on path 1.7.0 and hive_flutter 0.3.0+2 depends on path >=1.6.0 <1.7.0, flutter_test from sdk is incompatible with hive_flutter 0.3.0+2.
And because no versions of hive_flutter match >0.3.0+2 <0.4.0, flutter_test from sdk is incompatible with hive_flutter ^0.3.0+2.
So, because app depends on both hive_flutter ^0.3.0+2 and flutter_test any from sdk, version solving failed.
pub get failed (1; So, because app depends on both hive_flutter ^0.3.0+2 and flutter_test any from sdk, version solving failed.)
```

Fixes #285.