### PR TITLE
Updated dependencies

### DIFF
--- a/hive_flutter/pubspec.yaml
+++ b/hive_flutter/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   hive: ">=1.0.0 <2.0.0"
-  path_provider: "2.0.0"
+  path_provider: "1.6.7"
   path: "1.7.0"
 
 dev_dependencies:

--- a/hive_flutter/pubspec.yaml
+++ b/hive_flutter/pubspec.yaml
@@ -12,8 +12,8 @@ dependencies:
     sdk: flutter
 
   hive: ">=1.0.0 <2.0.0"
-  path_provider: ">=1.0.0 <2.0.0"
-  path: ">=1.6.0 <1.7.0"
+  path_provider: "2.0.0"
+  path: "1.7.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
When using Hive with the latest version of Flutter, the following error is thrown: 
```
Because every version of flutter_localizations from sdk depends on path 1.7.0 and hive_flutter 0.3.0+1 depends on path >=1.6.0 <1.7.0, flutter_localizations from sdk is incompatible with hive_flutter 0.3.0+1.
So, because junto_beta_mobile depends on both flutter_localizations any from sdk and hive_flutter 0.3.0+1, version solving failed.
pub get failed (1; So, because junto_beta_mobile depends on both flutter_localizations any from sdk and hive_flutter 0.3.0+1, version solving failed.)
```
 This PR resolves this error by updating Path to explicitly use the latest version available matching the framework. 