### PR TITLE
Update dartx

### DIFF
--- a/hive/pubspec.yaml
+++ b/hive/pubspec.yaml
@@ -15,9 +15,6 @@ dev_dependencies:
   test: ^1.9.4
   mockito: ^4.1.1
   pedantic: ^1.9.0
-  dartx:
-    git:
-      url: https://github.com/yringler/dartx
-      ref: update-path 
-  path: ">=1.6.4 <=1.7.0"
+  dartx: ^0.2.0
+  path: ^1.6.4
   pointycastle: ^1.0.2

--- a/hive/pubspec.yaml
+++ b/hive/pubspec.yaml
@@ -15,6 +15,6 @@ dev_dependencies:
   test: ^1.9.4
   mockito: ^4.1.1
   pedantic: ^1.9.0
-  dartx: ^0.2.0
+  dartx: ^0.4.1
   path: ^1.6.4
   pointycastle: ^1.0.2

--- a/hive/pubspec.yaml
+++ b/hive/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hive
 description: Lightweight and blazing fast key-value database written in pure Dart. Strongly encrypted using AES-256.
-version: 1.4.1+1
+version: 1.4.1+2
 homepage: https://github.com/hivedb/hive/tree/master/hive
 documentation: https://docs.hivedb.dev/
 
@@ -15,6 +15,9 @@ dev_dependencies:
   test: ^1.9.4
   mockito: ^4.1.1
   pedantic: ^1.9.0
-  dartx: ">=0.2.0 <1.0.0"
-  path: ^1.6.4
+  dartx:
+    git:
+      url: https://github.com/yringler/dartx
+      ref: update-path 
+  path: ">=1.6.4 <=1.7.0"
   pointycastle: ^1.0.2

--- a/hive_generator/pubspec.yaml
+++ b/hive_generator/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   source_gen: ^0.9.4+4
   hive: ">=1.3.0 <2.0.0"
   analyzer: ">=0.36.0 <0.40.0"
-  dartx: ^0.2.0
+  dartx: ^0.4.1
 
 dev_dependencies:
   test: ^1.6.4

--- a/hive_generator/pubspec.yaml
+++ b/hive_generator/pubspec.yaml
@@ -10,11 +10,7 @@ environment:
 dependencies:
   build: ^1.1.6
   source_gen: ^0.9.4+4
-  hive:
-    git:
-      url: https://github.com/yringler/hive
-      path: hive
-      ref: update-dartx
+  hive: ">=1.3.0 <2.0.0"
   analyzer: ">=0.36.0 <0.40.0"
   dartx: ^0.2.0
 

--- a/hive_generator/pubspec.yaml
+++ b/hive_generator/pubspec.yaml
@@ -16,10 +16,7 @@ dependencies:
       path: hive
       ref: update-dartx
   analyzer: ">=0.36.0 <0.40.0"
-  dartx:
-    git:
-      url: https://github.com/yringler/dartx
-      ref: update-path 
+  dartx: ^0.2.0
 
 dev_dependencies:
   test: ^1.6.4

--- a/hive_generator/pubspec.yaml
+++ b/hive_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hive_generator
 description: Extension for Hive. Automatically generates TypeAdapters to store any class.
-version: 0.7.0+2
+version: 0.7.0+3
 homepage: https://github.com/hivedb/hive/tree/master/hive_generator
 documentation: https://docs.hivedb.dev/
 
@@ -12,7 +12,10 @@ dependencies:
   source_gen: ^0.9.4+4
   hive: ">=1.3.0 <2.0.0"
   analyzer: ">=0.36.0 <0.40.0"
-  dartx: ">=0.2.0 <1.0.0"
+  dartx:
+    git:
+      url: https://github.com/yringler/dartx
+      ref: update-path 
 
 dev_dependencies:
   test: ^1.6.4

--- a/hive_generator/pubspec.yaml
+++ b/hive_generator/pubspec.yaml
@@ -10,7 +10,11 @@ environment:
 dependencies:
   build: ^1.1.6
   source_gen: ^0.9.4+4
-  hive: ">=1.3.0 <2.0.0"
+  hive:
+    git:
+      url: https://github.com/yringler/hive
+      path: hive
+      ref: update-dartx
   analyzer: ">=0.36.0 <0.40.0"
   dartx:
     git:


### PR DESCRIPTION
I don't know why exactly, but the current pubspecs don't allow the latest dartx.
I get this lovable error:
```
Running "flutter pub get" in just_audio_service...              
Because hive_generator >=0.6.0 depends on dartx ^0.2.0 which depends on path >=1.6.4 <1.7.0, hive_generator >=0.6.0 requires path >=1.6.4 <1.7.0.

And because just_audio 0.2.0 depends on path ^1.7.0, hive_generator >=0.6.0 is incompatible with just_audio 0.2.0.

So, because just_audio_service depends on both just_audio 0.2.0 and hive_generator ^0.7.0+2, version solving failed.
pub get failed (1; So, because just_audio_service depends on both just_audio 0.2.0 and hive_generator ^0.7.0+2, version solving failed.)
exit code 1
```
See a [branch of my plugin](https://github.com/yringler/just_audio_service/tree/reproduce-dependency-issue) which reproduces the issue.

Updating dartx explicitly (as per [master](https://github.com/yringler/just_audio_service, which relies on my hive fork)) resolves this error.