### PR TITLE
Fixing issue with enums: Error running TypeAdapterGenerator

### DIFF
--- a/hive_generator/lib/src/type_adapter_generator.dart
+++ b/hive_generator/lib/src/type_adapter_generator.dart
@@ -57,7 +57,7 @@ class TypeAdapterGenerator extends GeneratorForAnnotation<HiveType> {
   }
 
   ClassElement getClass(Element element) {
-    check(element.kind == ElementKind.CLASS,
+    check(element.kind == ElementKind.CLASS || element.kind == ElementKind.ENUM,
         'Only classes or enums are allowed to be annotated with @HiveType.');
 
     return element as ClassElement;


### PR DESCRIPTION
See issues https://github.com/hivedb/hive/issues/361 and https://github.com/hivedb/hive/issues/364

Chanced check statement with OR conditional to allow for ElementKind.ENUM