### PR TITLE
Remove extra byte reservation in writeBoolList

### DIFF
--- a/hive/lib/src/binary/binary_writer_impl.dart
+++ b/hive/lib/src/binary/binary_writer_impl.dart
@@ -173,7 +173,7 @@ class BinaryWriterImpl extends BinaryWriter {
     if (writeLength) {
       writeUint32(length);
     }
-    _reserveBytes(length * 8);
+    _reserveBytes(length);
     for (var i = 0; i < length; i++) {
       _buffer[_offset++] = list[i] ? 1 : 0;
     }


### PR DESCRIPTION
`writeBoolList` method inside `binary_writer_impl.dart` is reserving `8 * length` bytes, where it should suffice to reserve only `length` bytes.

This change does not impact `readBoolList` of `BinaryReaderImpl`.