### PR TITLE
Support more types in binary reader and writer

### DIFF
--- a/hive/lib/src/binary/binary_reader.dart
+++ b/hive/lib/src/binary/binary_reader.dart
@@ -18,6 +18,9 @@ abstract class BinaryReader {
   /// Read a single byte.
   int readByte();
 
+  /// Read a single byte.
+  int peekByte();
+
   /// Get a [Uint8List] view which contains the next [bytes] bytes.
   Uint8List viewBytes(int bytes);
 
@@ -28,20 +31,65 @@ abstract class BinaryReader {
   /// Read two bytes as 16-bit unsigned integer.
   int readWord();
 
+  /// Peek two bytes as 16-bit unsigned integer.
+  int peekWord();
+
+  /// Read four bytes as 8-bit unsigned integer.
+  int readUint8();
+
+  /// Peek four bytes as 8-bit unsigned integer.
+  int peekUint8();
+
+  /// Read four bytes as 8-bit signed integer.
+  int readInt8();
+
+  /// Peek four bytes as 8-bit signed integer.
+  int peekInt8();
+
+  /// Read four bytes as 16-bit unsigned integer.
+  int readUint16();
+
+  /// Peek four bytes as 16-bit unsigned integer.
+  int peekUint16();
+
+  /// Read four bytes as 16-bit signed integer.
+  int readInt16();
+
+  /// Peek four bytes as 16-bit signed integer.
+  int peekInt16();
+
   /// Read four bytes as 32-bit signed integer.
   int readInt32();
+
+  /// Peek four bytes as 32-bit signed integer.
+  int peekInt32();
 
   /// Read four bytes as 32-bit unsigned integer.
   int readUint32();
 
+  /// Peek four bytes as 32-bit unsigned integer.
+  int peekUint32();
+
   /// Read eight bytes as 64-bit signed integer.
   int readInt();
+
+  /// Peek eight bytes as 64-bit signed integer.
+  int peekInt();
 
   /// Read eight bytes as 64-bit double.
   double readDouble();
 
+  /// Peek eight bytes as 64-bit double.
+  double peekDouble();
+
   /// Read a boolean.
   bool readBool();
+
+  /// Read a boolean.
+  bool peekBool();
+
+  /// Read a [BigInt].
+  BigInt readBigInt();
 
   /// Read [byteCount] bytes and decode an UTF-8 String.
   ///

--- a/hive/lib/src/binary/binary_reader.dart
+++ b/hive/lib/src/binary/binary_reader.dart
@@ -88,9 +88,6 @@ abstract class BinaryReader {
   /// Read a boolean.
   bool peekBool();
 
-  /// Read a [BigInt].
-  BigInt readBigInt();
-
   /// Read [byteCount] bytes and decode an UTF-8 String.
   ///
   /// If [byteCount] is not provided, it is read first.

--- a/hive/lib/src/binary/binary_reader_impl.dart
+++ b/hive/lib/src/binary/binary_reader_impl.dart
@@ -202,21 +202,6 @@ class BinaryReaderImpl extends BinaryReader {
   }
 
   @override
-  BigInt readBigInt() {
-    var sign = readBool();
-    var bitLength = readUint32();
-    _requireBytes((bitLength / 8).ceil());
-    var value = BigInt.zero;
-    for (var i = 0; i < bitLength; i += 8) {
-      value |= BigInt.from(_buffer[_offset++]) << i;
-    }
-    if (sign) {
-      value = -value;
-    }
-    return value;
-  }
-
-  @override
   String readString(
       [int byteCount,
       Converter<List<int>, String> decoder = BinaryReader.utf8Decoder]) {

--- a/hive/lib/src/binary/binary_writer.dart
+++ b/hive/lib/src/binary/binary_writer.dart
@@ -11,6 +11,18 @@ abstract class BinaryWriter {
   /// Write a 16-bit unsigned integer as two bytes.
   void writeWord(int value);
 
+  /// Write a 8-bit unsigned integer as two bytes.
+  void writeUint8(int value);
+
+  /// Write a 8-bit signed integer as two bytes.
+  void writeInt8(int value);
+
+  /// Write a 16-bit unsigned integer as two bytes.
+  void writeUint16(int value);
+
+  /// Write a 16-bit signed integer as two bytes.
+  void writeInt16(int value);
+
   /// Write a 32-bit signed integer as four bytes.
   void writeInt32(int value);
 
@@ -25,6 +37,9 @@ abstract class BinaryWriter {
 
   /// Write a boolean.
   void writeBool(bool value);
+
+  /// Write a [BigInt]
+  void writeBigInt(BigInt value);
 
   /// Encode the UTF-8 String [value] and write its bytes.
   void writeString(

--- a/hive/lib/src/binary/binary_writer.dart
+++ b/hive/lib/src/binary/binary_writer.dart
@@ -38,9 +38,6 @@ abstract class BinaryWriter {
   /// Write a boolean.
   void writeBool(bool value);
 
-  /// Write a [BigInt]
-  void writeBigInt(BigInt value);
-
   /// Encode the UTF-8 String [value] and write its bytes.
   void writeString(
     String value, {

--- a/hive/lib/src/binary/binary_writer_impl.dart
+++ b/hive/lib/src/binary/binary_writer_impl.dart
@@ -139,25 +139,6 @@ class BinaryWriterImpl extends BinaryWriter {
   }
 
   @override
-  void writeBigInt(BigInt value) {
-    if (value == null) {
-      throw ArgumentError.notNull();
-    }
-    var sign = value.sign < 0;
-    writeBool(sign);
-    if (sign) {
-      value = -value;
-    }
-    var bitLength = value.bitLength;
-    writeUint32(bitLength);
-    _reserveBytes((bitLength / 8).ceil());
-    for (var i = 0; i < bitLength; i += 8) {
-      _buffer[_offset++] = value.toUnsigned(8).toInt();
-      value >>= 8;
-    }
-  }
-
-  @override
   void writeString(
     String value, {
     bool writeByteCount = true,

--- a/hive/lib/src/binary/binary_writer_impl.dart
+++ b/hive/lib/src/binary/binary_writer_impl.dart
@@ -80,6 +80,26 @@ class BinaryWriterImpl extends BinaryWriter {
   }
 
   @override
+  void writeUint8(int value) {
+    writeByte(value);
+  }
+
+  @override
+  void writeInt8(int value) {
+    writeUint8(value);
+  }
+
+  @override
+  void writeUint16(int value) {
+    writeWord(value);
+  }
+
+  @override
+  void writeInt16(int value) {
+    writeUint16(value);
+  }
+
+  @override
   void writeInt32(int value) {
     if (value == null) {
       throw ArgumentError.notNull();
@@ -116,6 +136,25 @@ class BinaryWriterImpl extends BinaryWriter {
   @override
   void writeBool(bool value) {
     writeByte(value ? 1 : 0);
+  }
+
+  @override
+  void writeBigInt(BigInt value) {
+    if (value == null) {
+      throw ArgumentError.notNull();
+    }
+    var sign = value.sign < 0;
+    writeBool(sign);
+    if (sign) {
+      value = -value;
+    }
+    var bitLength = value.bitLength;
+    writeUint32(bitLength);
+    _reserveBytes((bitLength / 8).ceil());
+    for (var i = 0; i < bitLength; i += 8) {
+      _buffer[_offset++] = value.toUnsigned(8).toInt();
+      value >>= 8;
+    }
   }
 
   @override

--- a/hive/test/tests/binary/binary_reader_test.dart
+++ b/hive/test/tests/binary/binary_reader_test.dart
@@ -401,37 +401,6 @@ void main() {
       expect(() => br.peekBool(), throwsA(anything));
     });
 
-    test('.readBigInt()', () {
-      var byteData = ByteData(45)
-            ..setUint8(0, 0) // +1 sign = false
-            ..setUint32(1, 0, Endian.little) // +4 bitLength = 0
-            ..setUint8(5, 1) // +1 sign = true
-            ..setUint32(6, 1, Endian.little) // +4 bitLength = 1
-            ..setUint8(10, 1) // +1
-            ..setUint8(11, 1) // +1 sign = true
-            ..setUint32(12, 7, Endian.little) // +4 bitLength = 3
-            ..setUint8(16, 250) // +1
-            ..setUint8(17, 0) // +1 sign = true
-            ..setUint32(18, 67, Endian.little) // +4 bitLength = 3
-            ..setUint32(22, 0, Endian.little) // +4
-            ..setUint32(26, 0, Endian.little) // +4
-            ..setUint8(30, 4) // +1
-            ..setUint8(31, 1) // +1 sign = true
-            ..setUint32(32, 67, Endian.little) // +4 bitLength = 3
-            ..setUint32(36, 0, Endian.little) // +4
-            ..setUint32(40, 0, Endian.little) // +4
-            ..setUint8(44, 4) // +1
-          ;
-      var br = fromByteData(byteData);
-
-      expect(br.readBigInt(), BigInt.zero);
-      expect(br.readBigInt(), -BigInt.one);
-      expect(br.readBigInt(), BigInt.from(-250));
-      expect(br.readBigInt(), BigInt.one << 66);
-      expect(br.readBigInt(), -(BigInt.one << 66));
-      expect(() => br.readBigInt(), throwsA(anything));
-    });
-
     test('.readString()', () {
       var br = fromBytes([0, 0, 0, 0]);
       expect(br.readString(), '');

--- a/hive/test/tests/binary/binary_reader_test.dart
+++ b/hive/test/tests/binary/binary_reader_test.dart
@@ -56,6 +56,23 @@ void main() {
       expect(() => br.readByte(), throwsA(anything));
     });
 
+    test('.peekByte()', () {
+      var byteData = ByteData(3)
+        ..setUint8(1, 0)
+        ..setUint8(1, 17)
+        ..setUint8(2, 255);
+      var br = fromByteData(byteData);
+
+      expect(br.peekByte(), 0);
+      br.readByte();
+      expect(br.peekByte(), 17);
+      expect(br.peekByte(), 17);
+      br.readByte();
+      expect(br.peekByte(), 255);
+      br.readByte();
+      expect(() => br.peekByte(), throwsA(anything));
+    });
+
     test('.viewBytes()', () {
       var byteData = ByteData(3)
         ..setUint8(0, 0)
@@ -94,6 +111,135 @@ void main() {
       expect(() => br.readWord(), throwsA(anything));
     });
 
+    test('.peekWord()', () {
+      var byteData = ByteData(4)
+        ..setUint16(0, 0, Endian.little)
+        ..setUint16(2, 65535, Endian.little);
+      var br = fromByteData(byteData);
+
+      expect(br.peekWord(), 0);
+      br.readWord();
+      expect(br.peekWord(), 65535);
+      expect(br.peekWord(), 65535);
+      br.readWord();
+      expect(() => br.peekWord(), throwsA(anything));
+    });
+
+    test('.readUint8()', () {
+      var byteData = ByteData(3)
+        ..setUint8(0, 0)
+        ..setUint8(1, 17)
+        ..setUint8(2, 255);
+      var br = fromByteData(byteData);
+
+      expect(br.readUint8(), 0);
+      expect(br.readUint8(), 17);
+      expect(br.readUint8(), 255);
+      expect(() => br.readUint8(), throwsA(anything));
+    });
+
+    test('.peekUint8()', () {
+      var byteData = ByteData(3)
+        ..setUint8(1, 0)
+        ..setUint8(1, 17)
+        ..setUint8(2, 255);
+      var br = fromByteData(byteData);
+
+      expect(br.peekUint8(), 0);
+      br.readUint8();
+      expect(br.peekUint8(), 17);
+      expect(br.peekUint8(), 17);
+      br.readUint8();
+      expect(br.peekUint8(), 255);
+      br.readUint8();
+      expect(() => br.peekUint8(), throwsA(anything));
+    });
+
+    test('.readInt8()', () {
+      var byteData = ByteData(3)
+        ..setUint8(0, 0)
+        ..setUint8(1, 17)
+        ..setUint8(2, 255);
+      var br = fromByteData(byteData);
+
+      expect(br.readInt8(), 0);
+      expect(br.readInt8(), 17);
+      expect(br.readInt8(), -1);
+      expect(() => br.readInt8(), throwsA(anything));
+    });
+
+    test('.peekInt8()', () {
+      var byteData = ByteData(3)
+        ..setUint8(1, 0)
+        ..setUint8(1, 17)
+        ..setUint8(2, 255);
+      var br = fromByteData(byteData);
+
+      expect(br.peekInt8(), 0);
+      br.readInt8();
+      expect(br.peekInt8(), 17);
+      expect(br.peekInt8(), 17);
+      br.readInt8();
+      expect(br.peekInt8(), -1);
+      br.readInt8();
+      expect(() => br.peekInt8(), throwsA(anything));
+    });
+
+    test('.readUint16()', () {
+      var byteData = ByteData(4)
+        ..setUint16(0, 0, Endian.little)
+        ..setUint16(2, 65535, Endian.little);
+      var br = fromByteData(byteData);
+
+      expect(br.readUint16(), 0);
+      expect(br.readUint16(), 65535);
+      expect(() => br.readUint16(), throwsA(anything));
+    });
+
+    test('.peekUint16()', () {
+      var byteData = ByteData(4)
+        ..setUint16(0, 0, Endian.little)
+        ..setUint16(2, 65535, Endian.little);
+      var br = fromByteData(byteData);
+
+      expect(br.peekUint16(), 0);
+      br.readUint16();
+      expect(br.peekUint16(), 65535);
+      expect(br.peekUint16(), 65535);
+      br.readUint16();
+      expect(() => br.peekUint16(), throwsA(anything));
+    });
+
+    test('.readInt16()', () {
+      var byteData = ByteData(6)
+        ..setInt16(0, 0, Endian.little)
+        ..setInt16(2, 32767, Endian.little)
+        ..setInt16(4, -32767, Endian.little);
+      var br = fromByteData(byteData);
+
+      expect(br.readInt16(), 0);
+      expect(br.readInt16(), 32767);
+      expect(br.readInt16(), -32767);
+      expect(() => br.readInt16(), throwsA(anything));
+    });
+
+    test('.peekInt16()', () {
+      var byteData = ByteData(6)
+        ..setInt16(0, 0, Endian.little)
+        ..setInt16(2, 32767, Endian.little)
+        ..setInt16(4, -32767, Endian.little);
+      var br = fromByteData(byteData);
+
+      expect(br.peekInt16(), 0);
+      br.readInt16();
+      expect(br.peekInt16(), 32767);
+      expect(br.peekInt16(), 32767);
+      br.readInt16();
+      expect(br.peekInt16(), -32767);
+      br.readInt16();
+      expect(() => br.peekInt16(), throwsA(anything));
+    });
+
     test('.readInt32()', () {
       var byteData = ByteData(12)
         ..setInt32(0, 0, Endian.little)
@@ -107,6 +253,23 @@ void main() {
       expect(() => br.readInt32(), throwsA(anything));
     });
 
+    test('.peekInt32()', () {
+      var byteData = ByteData(12)
+        ..setInt32(0, 0, Endian.little)
+        ..setInt32(4, 65535, Endian.little)
+        ..setInt32(8, -65536, Endian.little);
+      var br = fromByteData(byteData);
+
+      expect(br.peekInt32(), 0);
+      br.readInt32();
+      expect(br.peekInt32(), 65535);
+      expect(br.peekInt32(), 65535);
+      br.readInt32();
+      expect(br.peekInt32(), -65536);
+      br.readInt32();
+      expect(() => br.peekInt32(), throwsA(anything));
+    });
+
     test('.readUint32()', () {
       var byteData = ByteData(8)
         ..setUint32(0, 0, Endian.little)
@@ -116,6 +279,20 @@ void main() {
       expect(br.readUint32(), 0);
       expect(br.readUint32(), 4294967295);
       expect(() => br.readUint32(), throwsA(anything));
+    });
+
+    test('.peekUint32()', () {
+      var byteData = ByteData(8)
+        ..setUint32(0, 0, Endian.little)
+        ..setUint32(4, 4294967295, Endian.little);
+      var br = fromByteData(byteData);
+
+      expect(br.peekUint32(), 0);
+      br.readUint32();
+      expect(br.peekUint32(), 4294967295);
+      expect(br.peekUint32(), 4294967295);
+      br.readUint32();
+      expect(() => br.peekUint32(), throwsA(anything));
     });
 
     test('.readInt()', () {
@@ -129,6 +306,23 @@ void main() {
       expect(br.readInt(), 2 ^ 53);
       expect(br.readInt(), -2 ^ 53);
       expect(() => br.readInt(), throwsA(anything));
+    });
+
+    test('.peekInt()', () {
+      var byteData = ByteData(24)
+        ..setFloat64(0, 0, Endian.little)
+        ..setFloat64(8, (2 ^ 53).toDouble(), Endian.little)
+        ..setFloat64(16, (-2 ^ 53).toDouble(), Endian.little);
+      var br = fromByteData(byteData);
+
+      expect(br.peekInt(), 0);
+      br.readInt();
+      expect(br.peekInt(), 2 ^ 53);
+      br.readInt();
+      expect(br.peekInt(), -2 ^ 53);
+      expect(br.peekInt(), -2 ^ 53);
+      br.readInt();
+      expect(() => br.peekInt(), throwsA(anything));
     });
 
     test('.readDouble()', () {
@@ -150,6 +344,33 @@ void main() {
       expect(() => br.readDouble(), throwsA(anything));
     });
 
+    test('.peekDouble()', () {
+      var byteData = ByteData(48)
+        ..setFloat64(0, 0, Endian.little)
+        ..setFloat64(8, double.nan, Endian.little)
+        ..setFloat64(16, double.infinity, Endian.little)
+        ..setFloat64(24, double.negativeInfinity, Endian.little)
+        ..setFloat64(32, double.maxFinite, Endian.little)
+        ..setFloat64(40, double.minPositive, Endian.little);
+      var br = fromByteData(byteData);
+
+      expect(br.peekDouble(), 0);
+      br.readDouble();
+      expect(br.peekDouble().isNaN, true);
+      expect(br.peekDouble().isNaN, true);
+      br.readDouble();
+      expect(br.peekDouble(), double.infinity);
+      br.readDouble();
+      expect(br.peekDouble(), double.negativeInfinity);
+      br.readDouble();
+      expect(br.peekDouble(), double.maxFinite);
+      expect(br.peekDouble(), double.maxFinite);
+      br.readDouble();
+      expect(br.peekDouble(), double.minPositive);
+      br.readDouble();
+      expect(() => br.peekDouble(), throwsA(anything));
+    });
+
     test('.readBool()', () {
       var byteData = ByteData(3)
         ..setUint8(0, 1)
@@ -161,6 +382,54 @@ void main() {
       expect(br.readBool(), false);
       expect(br.readBool(), true);
       expect(() => br.readBool(), throwsA(anything));
+    });
+
+    test('.peekBool()', () {
+      var byteData = ByteData(3)
+        ..setUint8(0, 1)
+        ..setUint8(1, 0)
+        ..setUint8(2, 2);
+      var br = fromByteData(byteData);
+
+      expect(br.peekBool(), true);
+      br.readBool();
+      expect(br.peekBool(), false);
+      br.readBool();
+      expect(br.peekBool(), true);
+      expect(br.peekBool(), true);
+      br.readBool();
+      expect(() => br.peekBool(), throwsA(anything));
+    });
+
+    test('.readBigInt()', () {
+      var byteData = ByteData(45)
+            ..setUint8(0, 0) // +1 sign = false
+            ..setUint32(1, 0, Endian.little) // +4 bitLength = 0
+            ..setUint8(5, 1) // +1 sign = true
+            ..setUint32(6, 1, Endian.little) // +4 bitLength = 1
+            ..setUint8(10, 1) // +1
+            ..setUint8(11, 1) // +1 sign = true
+            ..setUint32(12, 7, Endian.little) // +4 bitLength = 3
+            ..setUint8(16, 250) // +1
+            ..setUint8(17, 0) // +1 sign = true
+            ..setUint32(18, 67, Endian.little) // +4 bitLength = 3
+            ..setUint32(22, 0, Endian.little) // +4
+            ..setUint32(26, 0, Endian.little) // +4
+            ..setUint8(30, 4) // +1
+            ..setUint8(31, 1) // +1 sign = true
+            ..setUint32(32, 67, Endian.little) // +4 bitLength = 3
+            ..setUint32(36, 0, Endian.little) // +4
+            ..setUint32(40, 0, Endian.little) // +4
+            ..setUint8(44, 4) // +1
+          ;
+      var br = fromByteData(byteData);
+
+      expect(br.readBigInt(), BigInt.zero);
+      expect(br.readBigInt(), -BigInt.one);
+      expect(br.readBigInt(), BigInt.from(-250));
+      expect(br.readBigInt(), BigInt.one << 66);
+      expect(br.readBigInt(), -(BigInt.one << 66));
+      expect(() => br.readBigInt(), throwsA(anything));
     });
 
     test('.readString()', () {

--- a/hive/test/tests/binary/binary_writer_test.dart
+++ b/hive/test/tests/binary/binary_writer_test.dart
@@ -58,6 +58,98 @@ void main() {
       expect(() => bw.writeWord(null), throwsA(anything));
     });
 
+    test('.writeUint8()', () {
+      var bw = getWriter();
+      bw.writeUint8(0);
+      expect(bw.toBytes(), [0]);
+
+      bw = getWriter();
+      bw.writeUint8(17);
+      expect(bw.toBytes(), [17]);
+
+      bw = getWriter();
+      bw.writeUint8(255);
+      expect(bw.toBytes(), [255]);
+
+      bw = getWriter();
+      bw.writeUint8(257);
+      expect(bw.toBytes(), [1]);
+
+      expect(() => bw.writeUint8(null), throwsA(anything));
+    });
+
+    test('.writeInt8()', () {
+      var bw = getWriter();
+      bw.writeInt8(0);
+      expect(bw.toBytes(), [0]);
+
+      bw = getWriter();
+      bw.writeInt8(17);
+      expect(bw.toBytes(), [17]);
+
+      bw = getWriter();
+      bw.writeInt8(-1);
+      expect(bw.toBytes(), [255]);
+
+      bw = getWriter();
+      bw.writeInt8(257);
+      expect(bw.toBytes(), [1]);
+
+      bw = getWriter();
+      bw.writeInt8(-257);
+      expect(bw.toBytes(), [255]);
+
+      expect(() => bw.writeInt8(null), throwsA(anything));
+    });
+
+    test('.writeUint16()', () {
+      var bw = getWriter();
+      bw.writeUint16(0);
+      expect(bw.toBytes(), [0, 0]);
+
+      bw = getWriter();
+      bw.writeUint16(256);
+      expect(bw.toBytes(), [0, 1]);
+
+      bw = getWriter();
+      bw.writeUint16(65535);
+      expect(bw.toBytes(), [255, 255]);
+
+      bw = getWriter();
+      bw.writeUint16(65536);
+      expect(bw.toBytes(), [0, 0]);
+
+      expect(() => bw.writeUint16(null), throwsA(anything));
+    });
+
+    test('.writeInt16()', () {
+      var bw = getWriter();
+      bw.writeInt16(0);
+      expect(bw.toBytes(), [0, 0]);
+
+      bw = getWriter();
+      bw.writeInt16(256);
+      expect(bw.toBytes(), [0, 1]);
+
+      bw = getWriter();
+      bw.writeInt16(-1);
+      expect(bw.toBytes(), [255, 255]);
+
+      bw = getWriter();
+      bw.writeInt16(65536);
+      expect(bw.toBytes(), [0, 0]);
+
+      bw = getWriter();
+      bw.writeInt16(-65536);
+      expect(bw.toBytes(), [0, 0]);
+
+      bw = getWriter();
+      bw.writeInt16(-65535);
+      expect(bw.toBytes(), [1, 0]);
+
+      expect(() => bw.writeInt16(null), throwsA(anything));
+    });
+
     test('.writeInt32()', () {
       var bd = ByteData(4);
 
@@ -207,6 +299,34 @@ void main() {
       expect(bw.toBytes(), [0]);
 
       expect(() => bw.writeBool(null), throwsA(anything));
+    });
+
+    test('.writeBigInt()', () {
+      var bw = getWriter();
+      bw.writeBigInt(BigInt.zero);
+      expect(bw.toBytes(), [0, 0, 0, 0, 0]);
+
+      bw = getWriter();
+      bw.writeBigInt(BigInt.one);
+      expect(bw.toBytes(), [0, 1, 0, 0, 0, 1]);
+
+      bw = getWriter();
+      bw.writeBigInt(-BigInt.one);
+      expect(bw.toBytes(), [1, 1, 0, 0, 0, 1]);
+
+      bw = getWriter();
+      bw.writeBigInt(-BigInt.two);
+      expect(bw.toBytes(), [1, 2, 0, 0, 0, 2]);
+
+      bw = getWriter();
+      bw.writeBigInt(BigInt.one << 66);
+      expect(bw.toBytes(), [0, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4]);
+
+      bw = getWriter();
+      bw.writeBigInt(-(BigInt.one << 66));
+      expect(bw.toBytes(), [1, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4]);
+
+      expect(() => bw.writeBigInt(null), throwsA(anything));
     });
 
     test('.writeString()', () {

--- a/hive/test/tests/binary/binary_writer_test.dart
+++ b/hive/test/tests/binary/binary_writer_test.dart
@@ -301,34 +301,6 @@ void main() {
       expect(() => bw.writeBool(null), throwsA(anything));
     });
 
-    test('.writeBigInt()', () {
-      var bw = getWriter();
-      bw.writeBigInt(BigInt.zero);
-      expect(bw.toBytes(), [0, 0, 0, 0, 0]);
-
-      bw = getWriter();
-      bw.writeBigInt(BigInt.one);
-      expect(bw.toBytes(), [0, 1, 0, 0, 0, 1]);
-
-      bw = getWriter();
-      bw.writeBigInt(-BigInt.one);
-      expect(bw.toBytes(), [1, 1, 0, 0, 0, 1]);
-
-      bw = getWriter();
-      bw.writeBigInt(-BigInt.two);
-      expect(bw.toBytes(), [1, 2, 0, 0, 0, 2]);
-
-      bw = getWriter();
-      bw.writeBigInt(BigInt.one << 66);
-      expect(bw.toBytes(), [0, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4]);
-
-      bw = getWriter();
-      bw.writeBigInt(-(BigInt.one << 66));
-      expect(bw.toBytes(), [1, 67, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4]);
-
-      expect(() => bw.writeBigInt(null), throwsA(anything));
-    });
-
     test('.writeString()', () {
       var bw = getWriter();
       bw.writeString('');


### PR DESCRIPTION
This change adds some methods to BinaryWriter, BinaryWriterImpl, BinaryReader and BinaryReaderImpl.
Corresponding test methods are also added to binary_writer_test and binary_reader_test.

New supported types to read and write are:
- Uint8
- Int8
- Uint16
- Int16
- BigInt

Also, _peekSomething()_ could be a useful feature.
Added support to peek values for most of the easily accessible types.