### PR TITLE
Hive_generator built value support

### DIFF
--- a/hive_generator/lib/src/class_builder.dart
+++ b/hive_generator/lib/src/class_builder.dart
@@ -120,12 +120,13 @@ class ClassBuilder extends Builder {
   }
 
   String _builtCast(DartType type, String variable) {
+    final pfx = '$variable == null ? null : ';
     if (builtListChecker.isExactlyType(type)) {
-      return 'ListBuilder<${_typeParamsString(type)}>($variable as List)';
+      return '${pfx}ListBuilder<${_typeParamsString(type)}>($variable as List)';
     } else if (builtSetChecker.isExactlyType(type)) {
-      return 'SetBuilder<${_typeParamsString(type)}>($variable as List)';
+      return '${pfx}SetBuilder<${_typeParamsString(type)}>($variable as List)';
     } else if (builtMapChecker.isExactlyType(type)) {
-      return 'MapBuilder<${_typeParamsString(type)}>($variable as Map)';
+      return '${pfx}MapBuilder<${_typeParamsString(type)}>($variable as Map)';
     }
     return '($variable as ${_displayString(type)})?.toBuilder()';
   }

--- a/hive_generator/lib/src/class_builder.dart
+++ b/hive_generator/lib/src/class_builder.dart
@@ -127,7 +127,7 @@ class ClassBuilder extends Builder {
     } else if (builtMapChecker.isExactlyType(type)) {
       return 'MapBuilder<${_typeParamsString(type)}>($variable as Map)';
     }
-    return '($variable as ${_displayString(type)}).toBuilder()';
+    return '($variable as ${_displayString(type)})?.toBuilder()';
   }
 
   String _cast(DartType type, String variable) {

--- a/hive_generator/lib/src/enum_class_builder.dart
+++ b/hive_generator/lib/src/enum_class_builder.dart
@@ -1,0 +1,25 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:hive_generator/src/builder.dart';
+
+class EnumClassBuilder extends Builder {
+  EnumClassBuilder(
+    ClassElement cls,
+  ) : super(cls, null, null);
+
+  @override
+  String buildRead() {
+    // Read the name of the enum class from the single field
+    var code = StringBuffer()
+      ..writeln('return ${cls.name}.valueOf(reader.read() as String);');
+    return code.toString();
+  }
+
+  @override
+  String buildWrite() {
+    // Write the name of the enum class as the single field.
+    var code = StringBuffer()
+      ..writeln('writer') //
+      ..writeln('..write(obj.name);');
+    return code.toString();
+  }
+}


### PR DESCRIPTION
So, now TypeAdapter for Built value classes is correctly generated, the reading and the writing work fine. Support for BuiltMap, BuiltList and BuiltSet was added too, they are written as an regular List/Map and restored using (Set/List/Map)Builder, which does all the casting and validation. EnumClass is stored using the name, just like the regular built_value serialization, as the name can be overriden using an annotation. Yeah, i think thats it! [Here is an example](https://github.com/KalilDev/built_value_hive_example/)