### PR TITLE
Relax build dependency constraint for hive_generator

### DIFF
--- a/hive_generator/pubspec.yaml
+++ b/hive_generator/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.10.0 <3.0.0'
 
 dependencies:
-  build: ^1.5.2
+  build: ">=1.5.2 <3.0.0"
   source_gen: ">=0.9.10+1 <2.0.0"
   hive: ^2.0.0
   analyzer: ">=0.40.0 <2.0.0"


### PR DESCRIPTION
The latest version of `build_runner` depends on `build` 2.0.0 (the null-safe version). That conflicts with the current constraint on `build` in `hive_flutter`. This PR relaxes the constraint so `build` 2.0.0 is allowed.

Fixes #597.

EDIT: Oops, did a wrong `git commit --amend`, will try to fix 😅
EDIT2: Fixed :) 