### PR TITLE
Export hive from hive_flutter

### DIFF
--- a/hive_flutter/lib/hive_flutter.dart
+++ b/hive_flutter/lib/hive_flutter.dart
@@ -8,6 +8,8 @@ import 'package:hive/hive.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart' as path_helper;
 
+export 'package:hive/hive.dart';
+
 part 'src/box_extensions.dart';
 part 'src/hive_extensions.dart';
 part 'src/watch_box_builder.dart';


### PR DESCRIPTION
We always need hive when using hive_flutter, so:

This PR eliminates the need of the additional hive import when using hive_flutter by exporting hive in hive_flutter.