### PR TITLE
Add default key support to HiveType adapters

### DIFF
--- a/hive/lib/src/adapters/ignored_type_adapter.dart
+++ b/hive/lib/src/adapters/ignored_type_adapter.dart
@@ -8,6 +8,11 @@ class IgnoredTypeAdapter<T> implements TypeAdapter<T?> {
   final int typeId;
 
   @override
+  dynamic defaultKey(obj) {
+      return null;
+  }
+
+  @override
   T? read(BinaryReader reader) => null;
 
   @override

--- a/hive/lib/src/annotations/hive_field.dart
+++ b/hive/lib/src/annotations/hive_field.dart
@@ -22,5 +22,8 @@ class HiveField {
   /// ```
   final dynamic defaultValue;
 
-  const HiveField(this.index, {this.defaultValue});
+  /// Whether use this field as the default key of this type
+  final bool isKey;
+
+  const HiveField(this.index, {this.defaultValue, this.isKey = false});
 }

--- a/hive/lib/src/box/box_base_impl.dart
+++ b/hive/lib/src/box/box_base_impl.dart
@@ -108,7 +108,7 @@ abstract class BoxBaseImpl<E> implements BoxBase<E> {
 
   @override
   Future<int> add(E value) async {
-    var key = keystore.autoIncrement();
+    var key = _getDefaultKey(value);
     await put(key, value);
     return key;
   }
@@ -117,7 +117,7 @@ abstract class BoxBaseImpl<E> implements BoxBase<E> {
   Future<Iterable<int>> addAll(Iterable<E> values) async {
     var entries = <int, E>{};
     for (var value in values) {
-      entries[keystore.autoIncrement()] = value;
+      entries[_getDefaultKey(value)] = value;
     }
     await putAll(entries);
     return entries.keys;
@@ -182,6 +182,20 @@ abstract class BoxBaseImpl<E> implements BoxBase<E> {
     }
 
     await backend.deleteFromDisk();
+  }
+
+  dynamic _getDefaultKey(E value) {
+    var resolved = hive.findAdapterForValue(value);
+    if (resolved == null) {
+      return keystore.autoIncrement();
+    }
+    var adapter = resolved.adapter;
+    var key = adapter.defaultKey(value);
+    if (key == null) {
+      return keystore.autoIncrement();
+    } else {
+      return key;
+    }
   }
 }
 

--- a/hive/lib/src/registry/type_adapter.dart
+++ b/hive/lib/src/registry/type_adapter.dart
@@ -6,6 +6,11 @@ abstract class TypeAdapter<T> {
   /// Called for type registration
   int get typeId;
 
+  // Is called when the value is adding to box without a specific key.
+  dynamic defaultKey(T obj) {
+      return null;
+  }
+
   /// Is called when a value has to be decoded.
   T read(BinaryReader reader);
 

--- a/hive_generator/lib/src/builder.dart
+++ b/hive_generator/lib/src/builder.dart
@@ -7,8 +7,9 @@ class AdapterField {
   final String name;
   final DartType type;
   final DartObject? defaultValue;
+  final bool isKey;
 
-  AdapterField(this.index, this.name, this.type, this.defaultValue);
+  AdapterField(this.index, this.name, this.type, this.defaultValue, this.isKey);
 }
 
 abstract class Builder {

--- a/hive_generator/lib/src/helper.dart
+++ b/hive_generator/lib/src/helper.dart
@@ -6,10 +6,11 @@ import 'package:source_gen/source_gen.dart';
 final _hiveFieldChecker = const TypeChecker.fromRuntime(HiveField);
 
 class HiveFieldInfo {
-  HiveFieldInfo(this.index, this.defaultValue);
+  HiveFieldInfo(this.index, this.defaultValue, this.isKey);
 
   final int index;
   final DartObject? defaultValue;
+  final bool isKey;
 }
 
 HiveFieldInfo? getHiveFieldAnn(Element element) {
@@ -19,6 +20,7 @@ HiveFieldInfo? getHiveFieldAnn(Element element) {
   return HiveFieldInfo(
     obj.getField('index')!.toIntValue()!,
     obj.getField('defaultValue'),
+    obj.getField('isKey')!.toBoolValue()!,
   );
 }
 


### PR DESCRIPTION
Hi,

@janniklind had requested(#578) a feature to add `isKey` field to `HiveField` annotation and use the field with `isKey=true` as default key of that class instances in `add` function.

So I implemented it. Before this, the `add` method of the base box class was using `keystore.autoIncrement` as default key. Now there's ability for people to set one of that class getters as default key.

For example:
```dart
@HiveType(typeId: 1)
class Dog {
    @HiveField(0, isKey: true)
    int id; 

    @HiveField(1)
    String name;

    Dog(this.id, this.name);
}
```

and therefore in main function:

```dart
  var dog = Dog(26, "mydog");
  box.add(dog);
```

It will use 26 as the key of inserted dog.