### PR TITLE
Ensure HiveLists are treated as non-nullable in hive_generator

### DIFF
--- a/hive_generator/lib/src/class_builder.dart
+++ b/hive_generator/lib/src/class_builder.dart
@@ -93,7 +93,7 @@ class ClassBuilder extends Builder {
   String _cast(DartType type, String variable) {
     var suffix = _suffixFromType(type);
     if (hiveListChecker.isAssignableFromType(type)) {
-      return '($variable as HiveList$suffix).castHiveList()';
+      return '($variable as HiveList$suffix)$suffix.castHiveList()';
     } else if (iterableChecker.isAssignableFromType(type) &&
         !isUint8List(type)) {
       return '($variable as List$suffix)${_castIterable(type)}';

--- a/hive_generator/lib/src/class_builder.dart
+++ b/hive_generator/lib/src/class_builder.dart
@@ -93,7 +93,7 @@ class ClassBuilder extends Builder {
   String _cast(DartType type, String variable) {
     var suffix = _suffixFromType(type);
     if (hiveListChecker.isAssignableFromType(type)) {
-      return '($variable as HiveList$suffix)?.castHiveList()';
+      return '($variable as HiveList$suffix).castHiveList()';
     } else if (iterableChecker.isAssignableFromType(type) &&
         !isUint8List(type)) {
       return '($variable as List$suffix)${_castIterable(type)}';


### PR DESCRIPTION
Resolves error "The argument type 'HiveList<T>?' can't be assigned to the parameter type 'HiveList<T>'.

Closes issue #644.