### PR TITLE
Support dir

### DIFF
--- a/hive_flutter/lib/hive_flutter.dart
+++ b/hive_flutter/lib/hive_flutter.dart
@@ -1,10 +1,12 @@
 library hive_flutter;
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hive/hive.dart';
+import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart'
     if (dart.library.html) 'src/stub/path_provider.dart';
 import 'package:path/path.dart' if (dart.library.html) 'src/stub/path.dart'

--- a/hive_flutter/lib/hive_flutter.dart
+++ b/hive_flutter/lib/hive_flutter.dart
@@ -6,7 +6,6 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hive/hive.dart';
-import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart'
     if (dart.library.html) 'src/stub/path_provider.dart';
 import 'package:path/path.dart' if (dart.library.html) 'src/stub/path.dart'

--- a/hive_flutter/lib/src/hive_extensions.dart
+++ b/hive_flutter/lib/src/hive_extensions.dart
@@ -2,14 +2,53 @@ part of hive_flutter;
 
 /// Flutter extensions for Hive.
 extension HiveX on HiveInterface {
-  /// Initializes Hive with the path from [getApplicationDocumentsDirectory].
+  /// Initializes Hive with the path from [getApplicationSupportDirectory].
   ///
   /// You can provide a [subDir] where the boxes should be stored.
   Future<void> initFlutter([String? subDir]) async {
     WidgetsFlutterBinding.ensureInitialized();
     if (kIsWeb) return;
 
-    var appDir = await getApplicationDocumentsDirectory();
-    init(path_helper.join(appDir.path, subDir));
+    // Get the directory that Hive uses to stor DB files (support dir + subdir).
+    final supportDir = await getApplicationSupportDirectory();
+    final appDir = path_helper.join(supportDir.path, subDir);
+
+    // If the app dir doesn't exist, create it. This is usually handled later on
+    // in Hive but the directory needs to exist to copy old DB files over.
+    if (!await Directory(appDir).exists()) {
+      await Directory(appDir).create();
+    }
+
+    // Get the old location that Hive used to store files.
+    final documentsDir = await getApplicationDocumentsDirectory();
+    final oldLocationDir =
+        Directory(path_helper.join(documentsDir.path, subDir));
+
+    // If the old location exists, we start looking for old DB files to copy.
+    if (await oldLocationDir.exists()) {
+      // Make an array to store files to copy.
+      final filesToCopy = <FileSystemEntity>[];
+
+      await oldLocationDir.list().forEach((event) {
+        final extension = path.extension(event.path);
+
+        // If the item is a file and has an extension of .hive/.lock, add it to
+        // the copy array.
+        if (extension is File &&
+            (extension == '.hive' || extension == '.lock')) {
+          filesToCopy.add(event);
+        }
+      });
+
+      // Make copy/delete futures for every file and wait for them
+      // asynchronously. Files are copied to the new appDir.
+      await Future.wait(filesToCopy.map(
+        (e) => File(e.path)
+            .copy(path_helper.join(appDir, path_helper.basename(e.path)))
+            .then((value) => File(e.path).delete()),
+      ));
+    }
+
+    init(appDir);
   }
 }

--- a/hive_flutter/lib/src/hive_extensions.dart
+++ b/hive_flutter/lib/src/hive_extensions.dart
@@ -30,7 +30,7 @@ extension HiveX on HiveInterface {
       final filesToCopy = <File>[];
 
       await oldLocationDir.list().forEach((event) {
-        final extension = path.extension(event.path);
+        final extension = path_helper.extension(event.path);
 
         // If the item is a file and has an extension of .hive, add it and the
         // matching .lock file to the copy array.
@@ -39,7 +39,8 @@ extension HiveX on HiveInterface {
 
           // We do this instead of just copying all .lock files since .lock can
           // commonly be used for non-Hive purposes.
-          filesToCopy.add(File(event.path.replaceAll('.hive', '.lock')));
+          filesToCopy
+              .add(File('${path_helper.withoutExtension(event.path)}.lock'));
         }
       });
 

--- a/hive_flutter/lib/src/hive_extensions.dart
+++ b/hive_flutter/lib/src/hive_extensions.dart
@@ -27,25 +27,28 @@ extension HiveX on HiveInterface {
     // If the old location exists, we start looking for old DB files to copy.
     if (await oldLocationDir.exists()) {
       // Make an array to store files to copy.
-      final filesToCopy = <FileSystemEntity>[];
+      final filesToCopy = <File>[];
 
       await oldLocationDir.list().forEach((event) {
         final extension = path.extension(event.path);
 
-        // If the item is a file and has an extension of .hive/.lock, add it to
-        // the copy array.
-        if (extension is File &&
-            (extension == '.hive' || extension == '.lock')) {
-          filesToCopy.add(event);
+        // If the item is a file and has an extension of .hive, add it and the
+        // matching .lock file to the copy array.
+        if (event is File && extension == '.hive') {
+          filesToCopy.add(File(event.path));
+
+          // We do this instead of just copying all .lock files since .lock can
+          // commonly be used for non-Hive purposes.
+          filesToCopy.add(File(event.path.replaceAll('.hive', '.lock')));
         }
       });
 
       // Make copy/delete futures for every file and wait for them
       // asynchronously. Files are copied to the new appDir.
       await Future.wait(filesToCopy.map(
-        (e) => File(e.path)
+        (e) => e
             .copy(path_helper.join(appDir, path_helper.basename(e.path)))
-            .then((value) => File(e.path).delete()),
+            .then((_) => e.delete()),
       ));
     }
 


### PR DESCRIPTION
Currently, Hive uses `getApplicationDocumentsDir` as a base directory to store files. On Android, this is fine since the documents dir is hidden from the user, but on iOS and Desktop, the documents dir is in a user-readable location. On iOS, it returns a folder in the user's "On My iPhone" section, and on Desktop it just returns the user's home or documents directory. This could confuse the user and may cause them to lose data by deleting the files. On iOS, the documents directory is also backed up to iCloud by default, which could annoy the user.

I have changed `initFlutter` to use `getApplicationSupportDir` instead. This returns a hidden location on all platforms. To handle DBs in old locations, the old location is looped through and all .hive/ files (and the accompanying .lock files) are copied to the new location. The vast majority of apps using Hive shouldn't have to do anything to migrate to this version, but this would probably require a major version bump since some developers may depend on interacting with the DB files directly for some reason.