### PR TITLE
Upgraded test package to null-safety

### DIFF
--- a/hive_flutter/pubspec.yaml
+++ b/hive_flutter/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/hivedb/hive/tree/master/hive_flutter
 documentation: https://docs.hivedb.dev/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
@@ -16,7 +16,7 @@ dependencies:
   path: ^1.8.0
 
 dev_dependencies:
-  test: ^1.15.7
+  test: ^1.17.11
   lints: ^1.0.1
   mockito: ^5.0.10
   build_runner: ^2.0.4


### PR DESCRIPTION
Hey everyone! Thanks for the amazing work done on this amazing package!

`test` package used in `hive_flutter` was set to [version 1.15.7](https://pub.dev/packages/test/versions), which is not using null-safety, so upgraded it to the newest version which supports null-safety. 

I noticed that currently `hive_flutter` package does not have the `null-safety` tag on pub.dev, and was wondering if this was the cause. I have a feeling since `test` package is just a dev dependency, it wouldn't matter, but just to be safe. 

<img width="775" alt="Screen Shot 2021-08-28 at 7 39 26" src="https://user-images.githubusercontent.com/18113850/131195338-efb1b9c9-fe74-4c29-a4ec-23de665d6c7d.png">
