### PR TITLE
Get indexDB selectively based on window property

### DIFF
--- a/hive/lib/src/backend/js/backend_manager.dart
+++ b/hive/lib/src/backend/js/backend_manager.dart
@@ -1,17 +1,20 @@
 import 'dart:html';
 import 'dart:indexed_db';
-
+import 'dart:js' as js;
 import 'package:hive/hive.dart';
 import 'package:hive/src/backend/js/storage_backend_js.dart';
 import 'package:hive/src/backend/storage_backend.dart';
 
 /// Opens IndexedDB databases
 class BackendManager implements BackendManagerInterface {
+  IdbFactory? get indexedDB => js.context.hasProperty('window')
+      ? window.indexedDB
+      : WorkerGlobalScope.instance.indexedDB;
+
   @override
   Future<StorageBackend> open(
       String name, String? path, bool crashRecovery, HiveCipher? cipher) async {
-    var db =
-        await window.indexedDB!.open(name, version: 1, onUpgradeNeeded: (e) {
+    var db = await indexedDB!.open(name, version: 1, onUpgradeNeeded: (e) {
       var db = e.target.result as Database;
       if (!db.objectStoreNames!.contains('box')) {
         db.createObjectStore('box');
@@ -23,7 +26,7 @@ class BackendManager implements BackendManagerInterface {
 
   @override
   Future<void> deleteBox(String name, String? path) {
-    return window.indexedDB!.deleteDatabase(name);
+    return indexedDB!.deleteDatabase(name);
   }
 
   @override
@@ -31,7 +34,7 @@ class BackendManager implements BackendManagerInterface {
     // https://stackoverflow.com/a/17473952
     try {
       var _exists = true;
-      await window.indexedDB!.open(name, version: 1, onUpgradeNeeded: (e) {
+      await indexedDB!.open(name, version: 1, onUpgradeNeeded: (e) {
         e.target.transaction!.abort();
         _exists = false;
       });

--- a/hive/lib/src/backend/js/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/storage_backend_js.dart
@@ -3,6 +3,7 @@ import 'dart:html';
 import 'dart:indexed_db';
 import 'dart:js_util';
 import 'dart:typed_data';
+import 'dart:js' as js;
 
 import 'package:hive/hive.dart';
 import 'package:hive/src/backend/storage_backend.dart';
@@ -199,6 +200,9 @@ class StorageBackendJs extends StorageBackend {
 
   @override
   Future<void> deleteFromDisk() {
-    return window.indexedDB!.deleteDatabase(_db.name!);
+    final indexDB = js.context.hasProperty('window')
+        ? window.indexedDB
+        : WorkerGlobalScope.instance.indexedDB;
+    return indexDB!.deleteDatabase(_db.name!);
   }
 }


### PR DESCRIPTION
Currently, for web platform, hive uses indexDB from browser' s window object. In our use case we need to do certain database operations in web worker, where indexDB is only accessible from `WorkerGlobalScope`. 

I understand that hive is not supposed to be used in web worker/isolate due to memory limitation, but our use case is simple and we will handle the call back carefully. 

Here is a minimum [example](https://github.com/WenhaoWu/hive_web_worker_example) of how we are going to use hive in web worker. Please have a look and let us know if this is acceptable from hive's perspective. 