### PR TITLE
Don't loose track of box objects if init crashes

### DIFF
--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -113,8 +113,8 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
           newBox = BoxImpl<E>(this, name, comparator, compaction, backend);
         }
 
-        await newBox.initialize();
         _boxes[name] = newBox;
+        await newBox.initialize();
 
         completer.complete();
         return newBox;


### PR DESCRIPTION
If Box.openBox raises an exception to due being corrupt or having an unknown type, the reference to the open file is dropped. The result of this is that on Windows, it is not possible to delete the corrupted box as .close() can't be called so Windows thinks the file is still in use.

This saves the reference to the open file before calling initialize() rather than afterwards.