### PR TITLE
Add types to generated adapter `read` method

### DIFF
--- a/hive_generator/lib/src/class_builder.dart
+++ b/hive_generator/lib/src/class_builder.dart
@@ -40,8 +40,8 @@ class ClassBuilder extends Builder {
 
     var code = StringBuffer();
     code.writeln('''
-    final numOfFields = reader.readByte();
-    final fields = <int, dynamic>{
+    final int numOfFields = reader.readByte();
+    final Map<int, dynamic> fields = <int, dynamic>{
       for (int i = 0; i < numOfFields; i++)
         reader.readByte(): reader.read(),
     };


### PR DESCRIPTION
Generated `read` method for adapters is currently missing types on two local variables (`numOfFields` and `fields`). This PR would add those types to the generated code.