### PR TITLE
Do not return uninitialized box

### DIFF
--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -107,8 +107,8 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
           newBox = BoxImpl<E>(this, name, comparator, compaction, backend);
         }
 
-        _boxes[name] = newBox;
         await newBox.initialize();
+        _boxes[name] = newBox;
 
         completer.complete();
         return newBox;


### PR DESCRIPTION
#846 fix should be rerolled.

```dart
_boxes[name] = newBox;
await newBox.initialize();
```

`_boxes` can contain a box which isn't initialized so it is possible that `isBoxOpen(name)` return `true` and program can acquire this uninitialized box which can lead serios problems for example `box.put` called.

Imagine the following situation:
```dart
var box = Hive.openBox('box');
var sameBox = Hive.openBox('box');
```

In this case `sameBox` can be referenced before it's initialized. However this cannot be achieved so easily because we have to get the reference after `_boxes[name] = newBox;` and during `await newBox.initialize();` call ([and also after `_manager.open`](https://github.com/Jon-Salmon/hive/blob/afef78771ba61892a9f2d716abc203aa4e9ef20f/hive/lib/src/hive_impl.dart#L105)).

**There is a period when both `isBoxOpen(name)` and `_openingBoxes.containsKey(name)` return `true`.**
Let me a show an example (_I won’t be bored with how the dart event loop works, this is the easiest example_):

```dart
import 'dart:async';
import 'dart:io';

import 'package:hive/hive.dart';
import 'package:hive/src/backend/storage_backend.dart';

import 'package:hive/src/hive_impl.dart';

const boxName = 'test_box';

final completer = Completer();

final f1 = Completer();
final f2 = Completer();

class BackendManagerInterceptor extends BackendManager {
  @override
  Future<StorageBackend> open(
      String name, String? path, bool crashRecovery, HiveCipher? cipher) async {
    final result = await super.open(name, path, crashRecovery, cipher);

    completer.complete();
    return result;
  }
}

void main() async {
  final sep = Platform.pathSeparator;
  final dbDirectory = Directory('${Directory.current.path}${sep}hive_db');

  print('dbDirectory: ${dbDirectory.path}');
  await resetAndInitDatabaseLocationPath(dbDirectory);

  final hive = HiveImpl.debug(BackendManagerInterceptor());
  hive.init(dbDirectory.path);

  var box = hive.openBox(boxName);
  box.then(
    (value) {
      print('Successful init');
      f1.complete();
    },
  );

  completer.future.then((value) {
    var sameBox = hive.openBox(boxName);
    sameBox.then(
      (value) {
        print('Box is avaible before it\'s initialized');
        f2.complete();
      },
    );
  });

  // make sure program doesn't exit before all print executed
  await (Future.wait([f1.future, f2.future]));
}

Future<void> resetAndInitDatabaseLocationPath(Directory dbDirectory) async {
  if (await dbDirectory.exists()) {
    await dbDirectory.delete(recursive: true);
  }
  await dbDirectory.create(recursive: true);
}

```

There is another fix just place `_openingBoxes.containsKey(name)` check before  `_boxes[name] = newBox;` however I think there shouldn't be any point in time when both return `true`, moreover in case of error [`_boxes` will contain an unitialized box](https://github.com/Jon-Salmon/hive/blob/afef78771ba61892a9f2d716abc203aa4e9ef20f/hive/lib/src/hive_impl.dart#L126).

#846 should use `Hive.deleteBoxFromDisk('boxName');` which handles the delete of unopened box ( _see implementation_ ).
```dart
  @override
  Future<void> deleteBoxFromDisk(String name, {String? path}) async {
    var lowerCaseName = name.toLowerCase();
    var box = _boxes[lowerCaseName];
    if (box != null) {
      await box.deleteFromDisk();
    } else {
      await _manager.deleteBox(lowerCaseName, path ?? homePath);
    }
  }
```