### PR TITLE
Support adapter type inheritance

### DIFF
--- a/hive/lib/src/registry/type_registry_impl.dart
+++ b/hive/lib/src/registry/type_registry_impl.dart
@@ -12,7 +12,9 @@ class ResolvedAdapter<T> {
 
   ResolvedAdapter(this.adapter, this.typeId);
 
-  bool matches(dynamic value) => value is T;
+  bool matchesRuntimeType(dynamic value) => value.runtimeType == T;
+
+  bool matchesType(dynamic value) => value is T;
 }
 
 class _NullTypeRegistry implements TypeRegistryImpl {
@@ -56,10 +58,16 @@ class TypeRegistryImpl implements TypeRegistry {
 
   /// Not part of public API
   ResolvedAdapter? findAdapterForValue(dynamic value) {
+    ResolvedAdapter? match;
     for (var adapter in _typeAdapters.values) {
-      if (adapter.matches(value)) return adapter;
+      if (adapter.matchesRuntimeType(value)) {
+        return adapter;
+      }
+      if (adapter.matchesType(value) && match == null) {
+        match = adapter;
+      }
     }
-    return null;
+    return match;
   }
 
   /// Not part of public API

--- a/hive/test/tests/registry/type_registry_impl_test.dart
+++ b/hive/test/tests/registry/type_registry_impl_test.dart
@@ -33,6 +33,40 @@ class TestAdapter2 extends TypeAdapter<int> {
   void write(BinaryWriter writer, obj) {}
 }
 
+class Parent {}
+
+class Child extends Parent {}
+
+class ParentAdapter extends TypeAdapter<Parent> {
+  ParentAdapter([this.typeId = 0]);
+
+  @override
+  final int typeId;
+
+  @override
+  Parent read(BinaryReader reader) {
+    return Parent();
+  }
+
+  @override
+  void write(BinaryWriter writer, Parent obj) {}
+}
+
+class ChildAdapter extends TypeAdapter<Child> {
+  ChildAdapter([this.typeId = 0]);
+
+  @override
+  final int typeId;
+
+  @override
+  Child read(BinaryReader reader) {
+    return Child();
+  }
+
+  @override
+  void write(BinaryWriter writer, Child obj) {}
+}
+
 void main() {
   group('TypeRegistryImpl', () {
     group('.registerAdapter()', () {
@@ -98,6 +132,30 @@ void main() {
         var resolvedAdapter = registry.findAdapterForValue(123)!;
         expect(resolvedAdapter.typeId, 32);
         expect(resolvedAdapter.adapter, adapter1);
+      });
+
+      test(
+          'returns adapter if exact runtime type of value matches ignoring registration order',
+          () {
+        final registry = TypeRegistryImpl();
+        final parentAdapter = ParentAdapter(0);
+        final childAdapter = ChildAdapter(1);
+        registry.registerAdapter(parentAdapter);
+        registry.registerAdapter(childAdapter);
+
+        final resolvedAdapter = registry.findAdapterForValue(Child());
+        expect(resolvedAdapter?.typeId, 33);
+        expect(resolvedAdapter?.adapter, childAdapter);
+      });
+
+      test('returns super type adapter for subtype', () {
+        final registry = TypeRegistryImpl();
+        final parentAdapter = ParentAdapter(0);
+        registry.registerAdapter(parentAdapter);
+
+        final resolvedAdapter = registry.findAdapterForValue(Child());
+        expect(resolvedAdapter?.typeId, 32);
+        expect(resolvedAdapter?.adapter, parentAdapter);
       });
     });
 


### PR DESCRIPTION
Let P be a super type and C its subtype.

In the current implementation, `TypeRegistryImpl.findAdapterForValue` always picks the first match for an adapter of C. This behavior is okay. However, when two type adapters, one for P and one for C got registered (first P and then C), then `TypeRegistryImpl.findAdapterForValue` will always return the adapter for P and never the more specific one for C.

This PR adjusts the behavior to first return an adapter that matches the **runtime type** of `value`. When no such adapter exists, then it falls back to how the current implementation behaves.
It also adds some tests for the new implementation.

Closes https://github.com/hivedb/hive/issues/880, closes https://github.com/hivedb/hive/issues/893 and maybe https://github.com/hivedb/hive/issues/821.

I am happy to make any adjustments required to (hopefully) merge this thing fast. 