### PR TITLE
Support UTF-8 keys

### DIFF
--- a/hive/lib/src/binary/binary_reader_impl.dart
+++ b/hive/lib/src/binary/binary_reader_impl.dart
@@ -220,7 +220,7 @@ class BinaryReaderImpl extends BinaryReader {
     if (keyType == FrameKeyType.uintT) {
       return readUint32();
     } else if (keyType == FrameKeyType.utf8StringT) {
-      var byteCount = readUint32();
+      var byteCount = readByte();
       return BinaryReader.utf8Decoder.convert(viewBytes(byteCount));
     } else {
       throw HiveError('Unsupported key type. Frame might be corrupted.');

--- a/hive/lib/src/binary/binary_reader_impl.dart
+++ b/hive/lib/src/binary/binary_reader_impl.dart
@@ -219,9 +219,9 @@ class BinaryReaderImpl extends BinaryReader {
     var keyType = readByte();
     if (keyType == FrameKeyType.uintT) {
       return readUint32();
-    } else if (keyType == FrameKeyType.asciiStringT) {
-      var keyLength = readByte();
-      return String.fromCharCodes(viewBytes(keyLength));
+    } else if (keyType == FrameKeyType.utf8StringT) {
+      var byteCount = readUint32();
+      return BinaryReader.utf8Decoder.convert(viewBytes(byteCount));
     } else {
       throw HiveError('Unsupported key type. Frame might be corrupted.');
     }

--- a/hive/lib/src/binary/binary_writer_impl.dart
+++ b/hive/lib/src/binary/binary_writer_impl.dart
@@ -244,7 +244,7 @@ class BinaryWriterImpl extends BinaryWriter {
     if (key is String) {
       writeByte(FrameKeyType.utf8StringT);
       var bytes = BinaryWriter.utf8Encoder.convert(key);
-      writeUint32(bytes.length);
+      writeByte(bytes.length);
       _addBytes(bytes);
     } else {
       writeByte(FrameKeyType.uintT);

--- a/hive/lib/src/binary/binary_writer_impl.dart
+++ b/hive/lib/src/binary/binary_writer_impl.dart
@@ -242,9 +242,10 @@ class BinaryWriterImpl extends BinaryWriter {
     ArgumentError.checkNotNull(key);
 
     if (key is String) {
-      writeByte(FrameKeyType.asciiStringT);
-      writeByte(key.length);
-      _addBytes(key.codeUnits);
+      writeByte(FrameKeyType.utf8StringT);
+      var bytes = BinaryWriter.utf8Encoder.convert(key);
+      writeUint32(bytes.length);
+      _addBytes(bytes);
     } else {
       writeByte(FrameKeyType.uintT);
       writeUint32(key as int);

--- a/hive/lib/src/binary/frame.dart
+++ b/hive/lib/src/binary/frame.dart
@@ -112,7 +112,7 @@ class FrameKeyType {
   static const uintT = 0;
 
   /// String key
-  static const asciiStringT = 1;
+  static const utf8StringT = 1;
 }
 
 /// Possible value types

--- a/hive/lib/src/binary/frame.dart
+++ b/hive/lib/src/binary/frame.dart
@@ -52,9 +52,8 @@ class Frame {
         throw HiveError('Integer keys need to be in the range 0 - 0xFFFFFFFF');
       }
     } else if (key is String) {
-      if (key.length > 0xFF || !key.isAscii) {
-        throw HiveError(
-            'String keys need to be ASCII Strings with a max length of 255');
+      if (key.length > 0xFF) {
+        throw HiveError('String keys need to be a max length of 255');
       }
     } else {
       throw HiveError('Keys need to be Strings or integers');

--- a/hive/lib/src/util/extensions.dart
+++ b/hive/lib/src/util/extensions.dart
@@ -2,17 +2,6 @@ import 'dart:math';
 import 'dart:typed_data';
 
 /// Not part of public API
-extension StringX on String {
-  /// Not part of public API
-  bool get isAscii {
-    for (var cu in codeUnits) {
-      if (cu > 127) return false;
-    }
-    return true;
-  }
-}
-
-/// Not part of public API
 extension ListIntX on List<int> {
   /// Not part of public API
   @pragma('vm:prefer-inline')

--- a/hive/lib/src/util/extensions.dart
+++ b/hive/lib/src/util/extensions.dart
@@ -2,6 +2,17 @@ import 'dart:math';
 import 'dart:typed_data';
 
 /// Not part of public API
+extension StringX on String {
+  /// Not part of public API
+  bool get isAscii {
+    for (var cu in codeUnits) {
+      if (cu > 127) return false;
+    }
+    return true;
+  }
+}
+
+/// Not part of public API
 extension ListIntX on List<int> {
   /// Not part of public API
   @pragma('vm:prefer-inline')

--- a/hive/test/tests/binary/frame_test.dart
+++ b/hive/test/tests/binary/frame_test.dart
@@ -33,9 +33,9 @@ void main() {
         Frame.lazy('a' * 255);
         Frame.deleted('a' * 255);
 
-        expect(() => Frame('hellö', null), throwsHiveError());
-        expect(() => Frame.lazy('hellö'), throwsHiveError());
-        expect(() => Frame.deleted('hellö'), throwsHiveError());
+        Frame('hellö', null);
+        Frame.lazy('hellö');
+        Frame.deleted('hellö');
 
         expect(() => Frame('a' * 256, null), throwsHiveError());
         expect(() => Frame.lazy('a' * 256), throwsHiveError());


### PR DESCRIPTION
This PR adds support for using unicode keys using UTF-8 encoding. There will be no backwards compatibility issue because ASCII is compatible with UTF-8 encoding.

Closes #159, #717, #412, #84, #37