### PR TITLE
generateSecureKey really returning list<int>

### DIFF
--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -232,7 +232,7 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
 
   @override
   List<int> generateSecureKey() {
-    return _secureRandom.nextBytes(32);
+    return _secureRandom.nextBytes(32).toList();
   }
 
   @override


### PR DESCRIPTION
generateSecureKey really returning list<int> instead uint8list.