### PR TITLE
fix: provide fallback backend manager

### DIFF
--- a/hive/test/integration/hive_list_test.dart
+++ b/hive/test/integration/hive_list_test.dart
@@ -1,5 +1,4 @@
 import 'package:hive/hive.dart';
-import 'package:hive/src/hive_impl.dart';
 import 'package:hive/src/object/hive_list_impl.dart';
 import 'package:test/test.dart';
 
@@ -38,7 +37,7 @@ class _TestObjectAdapter extends TypeAdapter<_TestObject> {
 
 void main() {
   test('add and remove objects to / from HiveList', () async {
-    var hive = HiveImpl();
+    var hive = await createHive();
     hive.registerAdapter(_TestObjectAdapter());
     var box = await openBox<_TestObject>(false, hive: hive) as Box<_TestObject>;
 

--- a/hive/test/integration/hive_object_test.dart
+++ b/hive/test/integration/hive_object_test.dart
@@ -1,5 +1,4 @@
 import 'package:hive/hive.dart';
-import 'package:hive/src/hive_impl.dart';
 import 'package:test/test.dart';
 
 import 'integration.dart';
@@ -32,8 +31,8 @@ class _TestObjectAdapter extends TypeAdapter<_TestObject> {
 }
 
 Future _performTest(bool lazy) async {
-  var hive = HiveImpl();
-  hive.registerAdapter(_TestObjectAdapter());
+  var hive = await createHive();
+  hive.registerAdapter<_TestObject>(_TestObjectAdapter());
   var box = await openBox(lazy, hive: hive);
 
   var obj1 = _TestObject('test1');

--- a/hive/test/integration/integration.dart
+++ b/hive/test/integration/integration.dart
@@ -14,17 +14,15 @@ Future<HiveImpl> createHive() async {
   if (!isBrowser) {
     var dir = await getTempDir();
     hive.init(dir.path);
+  } else {
+    hive.init(null);
   }
   return hive;
 }
 
 Future<BoxBase<T>> openBox<T>(bool lazy,
     {HiveInterface? hive, List<int>? encryptionKey}) async {
-  hive ??= HiveImpl();
-  if (!isBrowser) {
-    var dir = await getTempDir();
-    hive.init(dir.path);
-  }
+  hive ??= await createHive();
   var id = Random().nextInt(99999999);
   HiveCipher? cipher;
   if (encryptionKey != null) {

--- a/hive/test/integration/put_many_strings_test.dart
+++ b/hive/test/integration/put_many_strings_test.dart
@@ -5,8 +5,9 @@ import '../util/is_browser.dart';
 import 'integration.dart';
 
 Future _performTest(bool lazy) async {
+  var hive = await createHive();
   var repeat = isBrowser ? 20 : 1000;
-  var box = await openBox(lazy);
+  var box = await openBox(lazy, hive: hive);
   for (var i = 0; i < repeat; i++) {
     for (var frame in valueTestFrames) {
       await box.put('${frame.key}n$i', frame.value);

--- a/hive/test/tests/object/hive_list_impl_test.dart
+++ b/hive/test/tests/object/hive_list_impl_test.dart
@@ -1,11 +1,11 @@
 import 'dart:typed_data';
 
-import 'package:hive/src/hive_impl.dart';
 import 'package:hive/src/object/hive_list_impl.dart';
 import 'package:hive/src/object/hive_object.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
+import '../../integration/integration.dart';
 import '../common.dart';
 import '../mocks.dart';
 
@@ -47,14 +47,14 @@ void main() {
     });
 
     group('.box', () {
-      test('throws HiveError if box is not open', () {
-        var hive = HiveImpl();
+      test('throws HiveError if box is not open', () async {
+        var hive = await createHive();
         var hiveList = HiveListImpl.lazy('someBox', [])..debugHive = hive;
         expect(() => hiveList.box, throwsHiveError('you have to open the box'));
       });
 
       test('returns the box', () async {
-        var hive = HiveImpl();
+        var hive = await createHive();
         var box = await hive.openBox<int>('someBox', bytes: Uint8List(0));
         var hiveList = HiveListImpl.lazy('someBox', [])..debugHive = hive;
         expect(hiveList.box, box);


### PR DESCRIPTION
- remove need for manual `Hive.init()` call
- provide default backend manager
- fix most tests

Fixes: #967

Signed-off-by: TheOneWithTheBraid <the-one@with-the-braid.cf>