### PR TITLE
hive_generator: Update Analyzer version.

### DIFF
--- a/hive_generator/pubspec.yaml
+++ b/hive_generator/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   build: ^2.0.0
   source_gen: ^1.0.0
   hive: ^2.0.4
-  analyzer: ">=1.0.0 <4.0.0"
+  analyzer: ">=1.0.0 <5.0.0"
   source_helper: ^1.1.0
 
 dev_dependencies:


### PR DESCRIPTION
This PR is same as https://github.com/hivedb/hive/pull/858

Update Analyzer version `< 5.0.0`

Could someone merge this PR and release new version for hive_generator?