### PR TITLE
chore: allow Hive backend preferrence in Flutter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,10 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: ${{ matrix.flutter-channel }}
+      - name: Override dependency version
+        run: |
+          echo -e "\ndependency_overrides:\n  win32: 2.6.1" >> pubspec.yaml
+        working-directory: hive_flutter
       - name: Install dependencies
         run: flutter pub get
         working-directory: hive_flutter

--- a/hive_flutter/lib/src/hive_extensions.dart
+++ b/hive_flutter/lib/src/hive_extensions.dart
@@ -5,11 +5,21 @@ extension HiveX on HiveInterface {
   /// Initializes Hive with the path from [getApplicationDocumentsDirectory].
   ///
   /// You can provide a [subDir] where the boxes should be stored.
-  Future<void> initFlutter([String? subDir]) async {
+  Future<void> initFlutter(
+      [String? subDir,
+      HiveStorageBackendPreference backendPreference =
+          HiveStorageBackendPreference.native]) async {
     WidgetsFlutterBinding.ensureInitialized();
-    if (kIsWeb) return;
 
-    var appDir = await getApplicationDocumentsDirectory();
-    init(path_helper.join(appDir.path, subDir));
+    String? path;
+    if (!kIsWeb) {
+      var appDir = await getApplicationDocumentsDirectory();
+      path = path_helper.join(appDir.path, subDir);
+    }
+
+    init(
+      path,
+      backendPreference: backendPreference,
+    );
   }
 }

--- a/hive_flutter/pubspec.yaml
+++ b/hive_flutter/pubspec.yaml
@@ -11,12 +11,12 @@ dependencies:
   flutter:
     sdk: flutter
 
-  hive: ^2.0.4
-  path_provider: ^2.0.2
-  path: ^1.8.0
+  hive: ^2.2.1
+  path_provider: ^2.0.10
+  path: ^1.8.2
 
 dev_dependencies:
-  test: ^1.15.7
-  lints: ^1.0.1
-  mockito: ^5.0.10
-  build_runner: ^2.0.4
+  test: ^1.21.1
+  lints: ^2.0.0
+  mockito: ^5.2.0
+  build_runner: ^2.1.11


### PR DESCRIPTION
- expose `backendPreferrence` to Hive Flutter

Signed-off-by: TheOneWithTheBraid <the-one@with-the-braid.cf>