### PR TITLE
feat: improve web performance of BoxCollections

### DIFF
--- a/hive/lib/hive.dart
+++ b/hive/lib/hive.dart
@@ -18,7 +18,9 @@ import 'package:hive/src/object/hive_object.dart';
 import 'package:hive/src/util/extensions.dart';
 import 'package:meta/meta.dart';
 
-export 'src/box_collection.dart';
+export 'src/box_collection/box_collection_stub.dart'
+    if (dart.library.html) 'package:hive/src/box_collection/box_collection_indexed_db.dart'
+    if (dart.library.io) 'package:hive/src/box_collection/box_collection.dart';
 export 'src/object/hive_object.dart' show HiveObject, HiveObjectMixin;
 
 part 'src/annotations/hive_field.dart';

--- a/hive/lib/src/box_collection/box_collection_stub.dart
+++ b/hive/lib/src/box_collection/box_collection_stub.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+import 'package:hive/hive.dart';
+
+abstract class BoxCollection {
+  String get name;
+  Set<String> get boxNames;
+
+  static Future<BoxCollection> open(
+    String name,
+    Set<String> boxNames, {
+    String? path,
+    HiveCipher? key,
+  }) {
+    throw UnimplementedError();
+  }
+
+  Future<CollectionBox<V>> openBox<V>(String name,
+      {bool preload = false,
+      CollectionBox<V> Function(String, BoxCollection)? boxCreator});
+
+  Future<void> transaction(
+    Future<void> Function() action, {
+    List<String>? boxNames,
+    bool readOnly = false,
+  });
+
+  void close();
+
+  Future<void> deleteFromDisk();
+}
+
+/// represents a [Box] being part of a [BoxCollection]
+abstract class CollectionBox<V> {
+  String get name;
+  BoxCollection get boxCollection;
+
+  Future<List<String>> getAllKeys();
+
+  Future<Map<String, V>> getAllValues();
+
+  Future<V?> get(String key);
+
+  Future<List<V?>> getAll(
+    List<String> keys,
+  );
+
+  Future<void> put(String key, V val, [Object? transaction]);
+
+  Future<void> delete(String key);
+
+  Future<void> deleteAll(List<String> keys);
+
+  Future<void> clear();
+
+  Future<void> flush();
+}

--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -238,6 +238,7 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
       {String? path, String? collection}) async {
     var lowerCaseName = name.toLowerCase();
     var box = _boxes[lowerCaseName];
+    print(box);
     if (box != null) {
       await box.deleteFromDisk();
     } else {


### PR DESCRIPTION
- adds a direct web-only implementation of BoxCollections
- migrates the previous BoxCollections interface into an abstract
  implementation
- the direct indexed DB calls on web significantly improve the response
  time of transactions as the required Dart code to be executed is less than 25 % of the previous state
- as web is generally slow, this should improve the speed and make it
  comparable to io-platforms
- behavior on io-platforms untouched

Please tell me whether you are okay with this implementation as it introduces more platform-specific code.

Signed-off-by: TheOneWithTheBraid <the-one@with-the-braid.cf>