### PR TITLE
Fix Regression #977 - Web not registering DateTimeAdapter

### DIFF
--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -33,19 +33,8 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
   String? homePath;
 
   /// Not part of public API
-  HiveImpl();
-
-  /// Not part of public API
-  @visibleForTesting
-  HiveImpl.debug(this._managerOverride) {
+  HiveImpl() {
     _registerDefaultAdapters();
-  }
-
-  /// Not part of public API
-  @visibleForTesting
-  HiveImpl.test() : _managerOverride = BackendManager.select() {
-    registerAdapter(DateTimeAdapter<DateTime>(), internal: true);
-    registerAdapter(BigIntAdapter(), internal: true);
   }
 
   /// either returns the preferred [BackendManagerInterface] or the
@@ -67,7 +56,6 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
   }) {
     homePath = path;
     _managerOverride = BackendManager.select(backendPreference);
-    _registerDefaultAdapters();
   }
 
   Future<BoxBase<E>> _openBox<E>(

--- a/hive/test/integration/recovery_test.dart
+++ b/hive/test/integration/recovery_test.dart
@@ -20,7 +20,7 @@ Future _performTest(bool lazy) async {
   framesSetLengthOffset(frames, frameBytes);
 
   var dir = await getTempDir();
-  var hive = HiveImpl.test();
+  var hive = HiveImpl();
   hive.init(dir.path);
 
   for (var i = 0; i < bytes.length; i++) {

--- a/hive/test/tests/frames.dart
+++ b/hive/test/tests/frames.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:hive/hive.dart';
+import 'package:hive/src/adapters/date_time_adapter.dart';
 import 'package:hive/src/binary/binary_writer_impl.dart';
 import 'package:hive/src/binary/frame.dart';
 import 'package:hive/src/hive_impl.dart';
@@ -12,7 +13,7 @@ export '../generated/frame_values_encrypted.g.dart';
 export '../generated/frames.g.dart';
 export '../generated/frames_encrypted.g.dart';
 
-TypeRegistry get testRegistry => HiveImpl.test();
+TypeRegistry get testRegistry => HiveImpl();
 
 class _HiveAesCipherStaticIV extends HiveAesCipher {
   _HiveAesCipherStaticIV() : super(Uint8List.fromList(List.filled(32, 1)));
@@ -78,8 +79,8 @@ List<Frame> get testFrames => <Frame>[
         'Map': {'Key': 'Val', 'Key2': 2}
       }),
       Frame('DateTime test', [
-        DateTime.fromMillisecondsSinceEpoch(0),
-        DateTime.fromMillisecondsSinceEpoch(1566656623020),
+        DateTimeWithoutTZ.fromMillisecondsSinceEpoch(0),
+        DateTimeWithoutTZ.fromMillisecondsSinceEpoch(1566656623020),
       ]),
       Frame('BigInt Test',
           BigInt.parse('1234567890123456789012345678901234567890'))


### PR DESCRIPTION
Regression was caused in #956 (4dbcd76) where `HiveImpl` no longer
called `_registerDefaultAdapters`, assuming that it would happen in
`init`, which is not necessary for web.

Also remove `HiveImpl.debug` and `HiveImpl.test`.

`HiveImpl.test` was masking some odd legacy behavior in tests, so this
fixes the test.
`HiveImpl.debug` is not used anywhere, and its funcationality can be
accomplished using `init`