### PR TITLE
perf: Reduce allocations when writing database

### DIFF
--- a/hive/lib/src/binary/binary_writer_impl.dart
+++ b/hive/lib/src/binary/binary_writer_impl.dart
@@ -11,7 +11,7 @@ import 'package:meta/meta.dart';
 
 /// Not part of public API
 class BinaryWriterImpl extends BinaryWriter {
-  static const _initBufferSize = 256;
+  static const _initBufferSize = 4096;
 
   final TypeRegistryImpl _typeRegistry;
   Uint8List _buffer = Uint8List(_initBufferSize);


### PR DESCRIPTION
In my profiling I found 2 things to take the most performance in our
application:
- the AES encryption
- Copies and allocations of Uint8Lists

Increasing the size of the initial buffer allocation to one page (4kB)
makes those allocations only show up marginally in my profiling. While
this is somewhat of a magic number, most systems use a page size of 4kB
or larger so that feels like a somewhat reasonable default.

While this slightly increases the default memory usage when using hive,
I would expect most boxes to have more than 256 bytes of data (which
includes key and value). If any application actually uses many boxes of
less than 256 bytes, they could probably save more memory by using fewer
boxes and at the same time probably improve performance.

Signed-off-by: Nicolas Werner <n.werner@famedly.com>