### PR TITLE
feat: improve BinaryWriter API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           channel: ${{ matrix.flutter-channel }}
       - name: Override dependency version
         run: |
-          echo -e "\ndependency_overrides:\n  win32: 2.6.1" >> pubspec.yaml
+          echo -e "\ndependency_overrides:\n  win32: 2.6.1\n  hive:\n    path: ../hive" >> pubspec.yaml
         working-directory: hive_flutter
       - name: Install dependencies
         run: flutter pub get

--- a/hive/README.md
+++ b/hive/README.md
@@ -164,6 +164,35 @@ class SettingsPage extends StatelessWidget {
 
 Boxes are cached and therefore fast enough to be used directly in the `build()` method of Flutter widgets.
 
+### Native AES crypto implementation
+
+When using Flutter, Hive supports native encryption using [package:cryptography](https://pub.dev/packages/cryptography)
+and [package:cryptography_flutter](https://pub.dev/packages/cryptography_flutter).
+
+Native AES implementations tremendously speed up operations on encrypted Boxes.
+
+Please follow these steps:
+
+1. add dependency to pubspec.yaml
+
+```yaml
+dependencies:
+  cryptography_flutter: ^2.0.2
+```
+
+2. enable native implementations
+
+```dart
+import 'package:cryptography_flutter/cryptography_flutter.dart';
+
+void main() {
+  // Enable Flutter cryptography
+  FlutterCryptography.enable();
+
+  // ....
+}
+```
+
 ## Benchmark
 
 |                                         1000 read iterations                                         |                                    1000 write iterations                                    |

--- a/hive/lib/src/backend/storage_backend_memory.dart
+++ b/hive/lib/src/backend/storage_backend_memory.dart
@@ -27,8 +27,8 @@ class StorageBackendMemory extends StorageBackend {
 
   @override
   Future<void> initialize(
-      TypeRegistry registry, Keystore? keystore, bool lazy) {
-    var recoveryOffset = _frameHelper.framesFromBytes(
+      TypeRegistry registry, Keystore? keystore, bool lazy) async {
+    var recoveryOffset = await _frameHelper.framesFromBytes(
       _bytes!, // Initialized at constructor and nulled after initialization
       keystore,
       registry,

--- a/hive/lib/src/backend/vm/storage_backend_vm.dart
+++ b/hive/lib/src/backend/vm/storage_backend_vm.dart
@@ -49,6 +49,9 @@ class StorageBackendVm extends StorageBackend {
 
   bool _compactionScheduled = false;
 
+  /// a cache for asynchronouse I/O operations
+  final Set<Future<void>> _ongoingTransactions = {};
+
   /// Not part of public API
   StorageBackendVm(
       this._file, this._lockFile, this._crashRecovery, this._cipher)
@@ -101,101 +104,129 @@ class StorageBackendVm extends StorageBackend {
   }
 
   @override
-  Future<dynamic> readValue(Frame frame) {
-    return _sync.syncRead(() async {
-      await readRaf.setPosition(frame.offset);
+  Future<dynamic> readValue(Frame frame) async {
+    Future<dynamic> operation() async {
+      await Future.wait(_ongoingTransactions);
+      await _sync.syncRead(() async {
+        await readRaf.setPosition(frame.offset);
 
-      var bytes = await readRaf.read(frame.length!);
+        var bytes = await readRaf.read(frame.length!);
 
-      var reader = BinaryReaderImpl(bytes, registry);
-      var readFrame = reader.readFrame(cipher: _cipher, lazy: false);
+        var reader = BinaryReaderImpl(bytes, registry);
+        var readFrame = await reader.readFrame(cipher: _cipher, lazy: false);
 
-      if (readFrame == null) {
-        throw HiveError(
-            'Could not read value from box. Maybe your box is corrupted.');
-      }
+        if (readFrame == null) {
+          throw HiveError(
+              'Could not read value from box. Maybe your box is corrupted.');
+        }
 
-      return readFrame.value;
-    });
+        return readFrame.value;
+      });
+    }
+
+    final operationFuture = operation.call();
+    _ongoingTransactions.add(operationFuture);
+    final result = await operationFuture;
+    _ongoingTransactions.remove(operationFuture);
+    return result;
   }
 
   @override
-  Future<void> writeFrames(List<Frame> frames) {
-    return _sync.syncWrite(() async {
-      var writer = BinaryWriterImpl(registry);
+  Future<void> writeFrames(List<Frame> frames) async {
+    var writer = BinaryWriterImpl(registry);
 
-      for (var frame in frames) {
-        frame.length = writer.writeFrame(frame, cipher: _cipher);
-      }
+    for (var frame in frames) {
+      frame.length = await writer.writeFrame(frame, cipher: _cipher);
+    }
+    Future<void> operation() async {
+      // adding to the end of the queue
+      await Future.wait(_ongoingTransactions);
+      await _sync.syncWrite(() async {
+        final bytes = writer.toBytes();
 
-      try {
-        await writeRaf.writeFrom(writer.toBytes());
-      } catch (e) {
-        await writeRaf.setPosition(writeOffset);
-        rethrow;
-      }
+        final cachedOffset = writeOffset;
+        try {
+          /// TODO(TheOneWithTheBraid): implement real transactions with cache
+          await writeRaf.writeFrom(bytes);
+        } catch (e) {
+          await writeRaf.setPosition(cachedOffset);
+          rethrow;
+        }
+      });
+    }
 
-      for (var frame in frames) {
-        frame.offset = writeOffset;
-        writeOffset += frame.length!;
-      }
-    });
+    final future = operation();
+    _ongoingTransactions.add(future);
+    future.then((value) => _ongoingTransactions.remove(future));
+
+    for (var frame in frames) {
+      frame.offset = writeOffset;
+      writeOffset += frame.length!;
+    }
   }
 
   @override
-  Future<void> compact(Iterable<Frame> frames) {
+  Future<void> compact(Iterable<Frame> frames) async {
     if (_compactionScheduled) return Future.value();
     _compactionScheduled = true;
 
-    return _sync.syncReadWrite(() async {
-      await readRaf.setPosition(0);
-      var reader = BufferedFileReader(readRaf);
+    Future<void> operation() async {
+      await Future.wait(_ongoingTransactions);
+      await _sync.syncReadWrite(() async {
+        await readRaf.setPosition(0);
+        var reader = BufferedFileReader(readRaf);
 
-      var fileDirectory = path.substring(0, path.length - 5);
-      var compactFile = File('$fileDirectory.hivec');
-      var compactRaf = await compactFile.open(mode: FileMode.write);
-      var writer = BufferedFileWriter(compactRaf);
+        var fileDirectory = path.substring(0, path.length - 5);
+        var compactFile = File('$fileDirectory.hivec');
+        var compactRaf = await compactFile.open(mode: FileMode.write);
+        var writer = BufferedFileWriter(compactRaf);
 
-      var sortedFrames = frames.toList();
-      sortedFrames.sort((a, b) => a.offset.compareTo(b.offset));
-      try {
-        for (var frame in sortedFrames) {
-          if (frame.offset == -1) continue; // Frame has not been written yet
-          if (frame.offset != reader.offset) {
-            var skip = frame.offset - reader.offset;
-            if (reader.remainingInBuffer < skip) {
-              if (await reader.loadBytes(skip) < skip) {
+        var sortedFrames = frames.toList();
+        sortedFrames.sort((a, b) => a.offset.compareTo(b.offset));
+        try {
+          for (var frame in sortedFrames) {
+            if (frame.offset == -1) continue; // Frame has not been written yet
+            if (frame.offset != reader.offset) {
+              var skip = frame.offset - reader.offset;
+              if (reader.remainingInBuffer < skip) {
+                if (await reader.loadBytes(skip) < skip) {
+                  throw HiveError('Could not compact box: Unexpected EOF.');
+                }
+              }
+              reader.skip(skip);
+            }
+
+            if (reader.remainingInBuffer < frame.length!) {
+              if (await reader.loadBytes(frame.length!) < frame.length!) {
                 throw HiveError('Could not compact box: Unexpected EOF.');
               }
             }
-            reader.skip(skip);
+            await writer.write(reader.viewBytes(frame.length!));
           }
-
-          if (reader.remainingInBuffer < frame.length!) {
-            if (await reader.loadBytes(frame.length!) < frame.length!) {
-              throw HiveError('Could not compact box: Unexpected EOF.');
-            }
-          }
-          await writer.write(reader.viewBytes(frame.length!));
+          await writer.flush();
+        } finally {
+          await compactRaf.close();
         }
-        await writer.flush();
-      } finally {
-        await compactRaf.close();
-      }
 
-      await readRaf.close();
-      await writeRaf.close();
-      await compactFile.rename(path);
-      await open();
+        await readRaf.close();
+        await writeRaf.close();
+        await compactFile.rename(path);
+        await open();
 
-      var offset = 0;
-      for (var frame in sortedFrames) {
-        if (frame.offset == -1) continue;
-        frame.offset = offset;
-        offset += frame.length!;
-      }
-      _compactionScheduled = false;
-    });
+        var offset = 0;
+        for (var frame in sortedFrames) {
+          if (frame.offset == -1) continue;
+          frame.offset = offset;
+          offset += frame.length!;
+        }
+        _compactionScheduled = false;
+      });
+    }
+
+    final future = operation();
+    _ongoingTransactions.add(future);
+    await future;
+    _ongoingTransactions.remove(future);
   }
 
   @override
@@ -216,7 +247,8 @@ class StorageBackendVm extends StorageBackend {
   }
 
   @override
-  Future<void> close() {
+  Future<void> close() async {
+    await Future.wait(_ongoingTransactions);
     return _sync.syncReadWrite(_closeInternal);
   }
 
@@ -229,9 +261,17 @@ class StorageBackendVm extends StorageBackend {
   }
 
   @override
-  Future<void> flush() {
-    return _sync.syncWrite(() async {
-      await writeRaf.flush();
-    });
+  Future<void> flush() async {
+    Future<void> operation() async {
+      await Future.wait(_ongoingTransactions);
+      await _sync.syncWrite(() async {
+        await writeRaf.flush();
+      });
+    }
+
+    final future = operation();
+    _ongoingTransactions.add(future);
+    await future;
+    _ongoingTransactions.remove(future);
   }
 }

--- a/hive/lib/src/binary/binary_reader_impl.dart
+++ b/hive/lib/src/binary/binary_reader_impl.dart
@@ -241,8 +241,8 @@ class BinaryReaderImpl extends BinaryReader {
   }
 
   /// Not part of public API
-  Frame? readFrame(
-      {HiveCipher? cipher, bool lazy = false, int frameOffset = 0}) {
+  Future<Frame?> readFrame(
+      {HiveCipher? cipher, bool lazy = false, int frameOffset = 0}) async {
     // frame length is stored on 4 bytes
     if (availableBytes < 4) return null;
 
@@ -275,7 +275,7 @@ class BinaryReaderImpl extends BinaryReader {
     } else if (cipher == null) {
       frame = Frame(key, read());
     } else {
-      frame = Frame(key, readEncrypted(cipher));
+      frame = Frame(key, await readEncrypted(cipher));
     }
 
     frame
@@ -332,10 +332,10 @@ class BinaryReaderImpl extends BinaryReader {
   /// Not part of public API
   @pragma('vm:prefer-inline')
   @pragma('dart2js:tryInline')
-  dynamic readEncrypted(HiveCipher cipher) {
+  Future<dynamic> readEncrypted(HiveCipher cipher) async {
     var inpLength = availableBytes;
     var out = Uint8List(inpLength);
-    var outLength = cipher.decrypt(_buffer, _offset, inpLength, out, 0);
+    var outLength = await cipher.decrypt(_buffer, _offset, inpLength, out, 0);
     _offset += inpLength;
 
     var valueReader = BinaryReaderImpl(out, _typeRegistry, outLength);

--- a/hive/lib/src/binary/binary_writer_impl.dart
+++ b/hive/lib/src/binary/binary_writer_impl.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -268,7 +269,7 @@ class BinaryWriterImpl extends BinaryWriter {
   }
 
   /// Not part of public API
-  int writeFrame(Frame frame, {HiveCipher? cipher}) {
+  Future<int> writeFrame(Frame frame, {HiveCipher? cipher}) async {
     ArgumentError.checkNotNull(frame);
 
     var startOffset = _offset;
@@ -281,7 +282,7 @@ class BinaryWriterImpl extends BinaryWriter {
       if (cipher == null) {
         write(frame.value);
       } else {
-        writeEncrypted(frame.value, cipher);
+        await writeEncrypted(frame.value, cipher);
       }
     }
 
@@ -394,8 +395,8 @@ class BinaryWriterImpl extends BinaryWriter {
   /// Not part of public API
   @pragma('vm:prefer-inline')
   @pragma('dart2js:tryInline')
-  void writeEncrypted(dynamic value, HiveCipher cipher,
-      {bool writeTypeId = true}) {
+  FutureOr<void> writeEncrypted(dynamic value, HiveCipher cipher,
+      {bool writeTypeId = true}) async {
     var valueWriter = BinaryWriterImpl(_typeRegistry)
       ..write(value, writeTypeId: writeTypeId);
     var inp = valueWriter._buffer;
@@ -403,7 +404,7 @@ class BinaryWriterImpl extends BinaryWriter {
 
     _reserveBytes(cipher.maxEncryptedSize(inp));
 
-    var len = cipher.encrypt(inp, 0, inpLength, _buffer, _offset);
+    var len = await cipher.encrypt(inp, 0, inpLength, _buffer, _offset);
 
     _offset += len;
   }

--- a/hive/lib/src/binary/frame_helper.dart
+++ b/hive/lib/src/binary/frame_helper.dart
@@ -7,18 +7,18 @@ import 'package:hive/src/box/keystore.dart';
 /// Not part of public API
 class FrameHelper {
   /// Not part of public API
-  int framesFromBytes(
+  Future<int> framesFromBytes(
     Uint8List bytes,
     Keystore? keystore,
     TypeRegistry registry,
     HiveCipher? cipher,
-  ) {
+  ) async {
     var reader = BinaryReaderImpl(bytes, registry);
 
     while (reader.availableBytes != 0) {
       var frameOffset = reader.usedBytes;
 
-      var frame = reader.readFrame(
+      var frame = await reader.readFrame(
         cipher: cipher,
         lazy: false,
         frameOffset: frameOffset,

--- a/hive/lib/src/box/box_base.dart
+++ b/hive/lib/src/box/box_base.dart
@@ -112,6 +112,12 @@ abstract class BoxBase<E> {
     bool notify = true,
   });
 
+  /// Beta: Performs the following write-only operations in memory and later
+  /// flushes
+  ///
+  /// This can be used to improve speed on many small write operations
+  // Future<void> transaction(Future<void> Function() operation);
+
   /// Deletes the given [key] from the box.
   ///
   /// If it does not exist, nothing happens.

--- a/hive/lib/src/box_collection/box_collection.dart
+++ b/hive/lib/src/box_collection/box_collection.dart
@@ -245,7 +245,7 @@ class CollectionBox<V> implements implementation.CollectionBox<V> {
     // other stuff while the flushing is still in progress. Fortunately, hive
     // has a proper read / write queue, meaning that if we do actually want to
     // write something again, it'll wait until the flush is completed.
-    box.flush();
+    await box.flush();
   }
 
   Future<void> _flushOrMark() async {

--- a/hive/lib/src/box_collection/box_collection.dart
+++ b/hive/lib/src/box_collection/box_collection.dart
@@ -240,12 +240,11 @@ class CollectionBox<V> implements implementation.CollectionBox<V> {
 
   @override
   Future<void> flush() async {
-    final box = await _getBox();
     // we do *not* await the flushing here. That makes it so that we can execute
     // other stuff while the flushing is still in progress. Fortunately, hive
     // has a proper read / write queue, meaning that if we do actually want to
     // write something again, it'll wait until the flush is completed.
-    await box.flush();
+    _getBox().then((box) => box.flush());
   }
 
   Future<void> _flushOrMark() async {

--- a/hive/lib/src/crypto/hive_aes_cipher.dart
+++ b/hive/lib/src/crypto/hive_aes_cipher.dart
@@ -24,7 +24,7 @@ class HiveAesCipher implements HiveCipher {
   int calculateKeyCrc() => _keyCrc;
 
   @override
-  int decrypt(
+  FutureOr<int> decrypt(
       Uint8List inp, int inpOff, int inpLength, Uint8List out, int outOff) {
     var iv = inp.view(inpOff, 16);
 
@@ -36,7 +36,7 @@ class HiveAesCipher implements HiveCipher {
   Uint8List generateIv() => _ivRandom.nextBytes(16);
 
   @override
-  int encrypt(
+  FutureOr<int> encrypt(
       Uint8List inp, int inpOff, int inpLength, Uint8List out, int outOff) {
     var iv = generateIv();
     out.setAll(outOff, iv);

--- a/hive/lib/src/crypto/hive_cipher.dart
+++ b/hive/lib/src/crypto/hive_cipher.dart
@@ -1,6 +1,10 @@
 part of hive;
 
 /// Abstract cipher can be implemented to customize encryption.
+///
+/// Encryption and decryption can be either synchronous (e.g. with the
+/// [HiveAesCipher] implementation) or asynchronous for use with
+/// hardware-accelerated crypto implementations.
 abstract class HiveCipher {
   /// Calculate a hash of the key. Make sure to use a secure hash.
   int calculateKeyCrc();
@@ -8,11 +12,26 @@ abstract class HiveCipher {
   /// The maximum size the input can have after it has been encrypted.
   int maxEncryptedSize(Uint8List inp);
 
-  /// Encrypt the given bytes.
-  int encrypt(
+  ///
+  /// - [inp]: the total bytes in plain text
+  /// - [inpOff]: the byte offset to start encryption at
+  /// - [inpLength]: the number of bytes (length) to encrypt
+  /// - [out]: the buffer to write the encrypted output in
+  /// - [outOff]: the byte offset to write the encrypted output to
+  ///
+  /// returns the length of the new encrypted output
+  FutureOr<int> encrypt(
       Uint8List inp, int inpOff, int inpLength, Uint8List out, int outOff);
 
   /// Decrypt the given bytes.
-  int decrypt(
+  ///
+  /// - [inp]: the total encrypted bytes
+  /// - [inpOff]: the byte offset to start decryption at
+  /// - [inpLength]: the number of bytes (length) to decrypt
+  /// - [out]: the buffer to write the decrypted output in
+  /// - [outOff]: the byte offset to write the decrypted output to
+  ///
+  /// returns the length of the new decrypted output
+  FutureOr<int> decrypt(
       Uint8List inp, int inpOff, int inpLength, Uint8List out, int outOff);
 }

--- a/hive/lib/src/io/frame_io_helper.dart
+++ b/hive/lib/src/io/frame_io_helper.dart
@@ -70,7 +70,7 @@ class _KeyReader {
         if (available < frameLength) return frameOffset;
       }
 
-      var frame = _reader.readFrame(
+      var frame = await _reader.readFrame(
         cipher: cipher,
         lazy: true,
         frameOffset: frameOffset,

--- a/hive/test/integration/delete_many_test.dart
+++ b/hive/test/integration/delete_many_test.dart
@@ -24,6 +24,8 @@ Future _performTest(bool lazy) async {
     await box.delete('null$i');
   }
 
+  await box.flush();
+
   box = await box.reopen();
   for (var i = 0; i < amount; i++) {
     expect(box.containsKey('string$i'), false);

--- a/hive/test/integration/put_many_same_key_test.dart
+++ b/hive/test/integration/put_many_same_key_test.dart
@@ -17,6 +17,7 @@ Future _performTest(bool lazy) async {
         await box.put('int$i', n);
         await box.put('bool$i', n % 2 == 0);
         await box.put('null$i', null);
+        await box.flush();
 
         expect(await await box.get('string$i'), 'test$n');
         expect(await await box.get('int$i'), n);
@@ -28,6 +29,8 @@ Future _performTest(bool lazy) async {
       await completer.future;
     }
   }
+
+  await box.flush();
 
   box = await box.reopen();
   for (var i = 0; i < amount; i++) {

--- a/hive/test/integration/put_many_simultaneously_test.dart
+++ b/hive/test/integration/put_many_simultaneously_test.dart
@@ -1,6 +1,3 @@
-import 'dart:developer';
-
-import 'package:hive/hive.dart';
 import 'package:test/test.dart';
 
 import '../util/is_browser.dart';

--- a/hive/test/integration/put_many_simultaneously_test.dart
+++ b/hive/test/integration/put_many_simultaneously_test.dart
@@ -1,3 +1,6 @@
+import 'dart:developer';
+
+import 'package:hive/hive.dart';
 import 'package:test/test.dart';
 
 import '../util/is_browser.dart';
@@ -18,6 +21,8 @@ Future _performTest(bool lazy) async {
     futures.add(putEntries());
   }
   await Future.wait(futures);
+
+  await box.flush();
 
   box = await box.reopen();
   for (var i = 0; i < amount; i++) {

--- a/hive/test/integration/recovery_test.dart
+++ b/hive/test/integration/recovery_test.dart
@@ -14,7 +14,7 @@ import '../tests/frames.dart';
 import 'integration.dart';
 
 Future _performTest(bool lazy) async {
-  var bytes = getFrameBytes(testFrames);
+  var bytes = await getFrameBytes(testFrames);
   var frames = testFrames;
 
   framesSetLengthOffset(frames, frameBytes);
@@ -46,7 +46,7 @@ Future _performTest(bool lazy) async {
       await box.close();
     }
 
-    expect(await boxFile.readAsBytes(), getFrameBytes(subFrames));
+    expect(await boxFile.readAsBytes(), await getFrameBytes(subFrames));
   }
 }
 

--- a/hive/test/tests/backend/vm/storage_backend_vm_test.dart
+++ b/hive/test/tests/backend/vm/storage_backend_vm_test.dart
@@ -252,6 +252,8 @@ void main() {
             .thenAnswer((i) => Future.value(writeRaf));
         when(() => writeRaf.writeFrom(bytes))
             .thenAnswer((i) => Future.value(writeRaf));
+        when(() => writeRaf.flush())
+            .thenAnswer((i) => Future.value(writeRaf));
 
         var backend = _getBackend(writeRaf: writeRaf)
           // The registry needs to be initialized before writing values, and

--- a/hive/test/tests/backend/vm/storage_backend_vm_test.dart
+++ b/hive/test/tests/backend/vm/storage_backend_vm_test.dart
@@ -25,7 +25,7 @@ const testMap = {
   'LastKey': true,
 };
 
-Uint8List getFrameBytes(Iterable<Frame> frames) {
+Future<Uint8List> getFrameBytes(Iterable<Frame> frames) async {
   var writer = BinaryWriterImpl(testRegistry);
   for (var frame in frames) {
     writer.writeFrame(frame);
@@ -211,7 +211,7 @@ void main() {
     group('.readValue()', () {
       test('reads value with offset', () async {
         var frameBytes = getFrameBytes([Frame('test', 123)]);
-        var readRaf = await getTempRaf([1, 2, 3, 4, 5, ...frameBytes]);
+        var readRaf = await getTempRaf([1, 2, 3, 4, 5, ...await frameBytes]);
 
         var backend = _getBackend(readRaf: readRaf)
           // The registry needs to be initialized before reading values, and
@@ -219,7 +219,7 @@ void main() {
           // manually.
           ..registry = TypeRegistryImpl.nullImpl;
         var value = await backend.readValue(
-          Frame('test', 123, length: frameBytes.length, offset: 5),
+          Frame('test', 123, length: (await frameBytes).length, offset: 5),
         );
         expect(value, 123);
 
@@ -245,7 +245,7 @@ void main() {
     group('.writeFrames()', () {
       test('writes bytes', () async {
         var frames = [Frame('key1', 'value'), Frame('key2', null)];
-        var bytes = getFrameBytes(frames);
+        var bytes = await getFrameBytes(frames);
 
         var writeRaf = MockRandomAccessFile();
         when(() => writeRaf.setPosition(0))
@@ -260,6 +260,7 @@ void main() {
           ..registry = TypeRegistryImpl.nullImpl;
 
         await backend.writeFrames(frames);
+        await backend.flush();
         verify(() => writeRaf.writeFrom(bytes));
       });
 
@@ -354,7 +355,7 @@ void main() {
 
       test('throws error if corrupted', () async {
         var bytes = BytesBuilder();
-        var boxFile = await getTempFile(); 
+        var boxFile = await getTempFile();
         var syncedFile = SyncedFile(boxFile.path);
         await syncedFile.open();
 

--- a/hive/test/tests/binary/binary_reader_test.dart
+++ b/hive/test/tests/binary/binary_reader_test.dart
@@ -366,82 +366,88 @@ void main() {
         Uint8List.fromList([10, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
       ];
 
-      test('null', () {
+      test('null', () async {
         for (final bytes in nullFramesBytes) {
           final reader = BinaryReaderImpl(bytes, testRegistry);
-          final frame = reader.readFrame(lazy: false);
+          final frame = await reader.readFrame(lazy: false);
 
           expect(frame, null);
         }
       });
 
-      test('null lazy', () {
+      test('null lazy', () async {
         for (final bytes in nullFramesBytes) {
           final reader = BinaryReaderImpl(bytes, testRegistry);
-          final frame = reader.readFrame(lazy: true);
+          final frame = await reader.readFrame(lazy: true);
 
           expect(frame, null);
         }
       });
 
-      test('normal', () {
+      test('normal', () async {
         var frames = framesSetLengthOffset(testFrames, frameBytes);
         var offset = 0;
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           var reader = BinaryReaderImpl(frameBytes[i], testRegistry);
+          final actual =
+              await reader.readFrame(lazy: false, frameOffset: offset);
           expectFrame(
-            reader.readFrame(lazy: false, frameOffset: offset)!,
+            actual!,
             frame,
           );
           offset += frameBytes[i].length;
         }
       });
 
-      test('lazy', () {
+      test('lazy', () async {
         var frames = framesSetLengthOffset(testFrames, frameBytes);
         var offset = 0;
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           var reader = BinaryReaderImpl(frameBytes[i], testRegistry);
+          final actual =
+              await reader.readFrame(lazy: true, frameOffset: offset);
           expectFrame(
-            reader.readFrame(lazy: true, frameOffset: offset)!,
+            actual!,
             frame.toLazy(),
           );
           offset += frameBytes[i].length;
         }
       });
 
-      test('encrypted', () {
+      test('encrypted', () async {
         var frames = framesSetLengthOffset(testFrames, frameBytesEncrypted);
         var offset = 0;
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           var reader = BinaryReaderImpl(frameBytesEncrypted[i], testRegistry);
+          final actual = await reader.readFrame(
+            lazy: false,
+            frameOffset: offset,
+            cipher: testCipher,
+          );
           expectFrame(
-            reader.readFrame(
-              lazy: false,
-              frameOffset: offset,
-              cipher: testCipher,
-            )!,
+            actual!,
             frame,
           );
           offset += frameBytesEncrypted[i].length;
         }
       });
 
-      test('encrypted lazy', () {
+      test('encrypted lazy', () async {
         var frames = framesSetLengthOffset(testFrames, frameBytesEncrypted);
         var offset = 0;
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           var reader = BinaryReaderImpl(frameBytesEncrypted[i], testRegistry);
+          final actual = await reader.readFrame(
+            lazy: true,
+            frameOffset: offset,
+            cipher: testCipher,
+          );
           expectFrame(
-            reader.readFrame(
-              lazy: true,
-              frameOffset: offset,
-              cipher: testCipher,
-            )!,
+            actual!,
             frame.toLazy(),
           );
           offset += frameBytesEncrypted[i].length;

--- a/hive/test/tests/binary/binary_writer_test.dart
+++ b/hive/test/tests/binary/binary_writer_test.dart
@@ -381,20 +381,20 @@ void main() {
     });
 
     group('.writeFrame()', () {
-      test('normal', () {
+      test('normal', () async {
         for (var i = 0; i < testFrames.length; i++) {
           final frame = testFrames[i];
           var writer = BinaryWriterImpl(testRegistry);
-          expect(writer.writeFrame(frame), frameBytes[i].length);
+          expect(await writer.writeFrame(frame), frameBytes[i].length);
           expect(writer.toBytes(), frameBytes[i]);
         }
       });
 
-      test('encrypted', () {
+      test('encrypted', () async {
         for (var i = 0; i < testFrames.length; i++) {
           final frame = testFrames[i];
           var writer = BinaryWriterImpl(testRegistry);
-          expect(writer.writeFrame(frame, cipher: testCipher),
+          expect(await writer.writeFrame(frame, cipher: testCipher),
               frameBytesEncrypted[i].length);
           expect(writer.toBytes(), frameBytesEncrypted[i]);
         }

--- a/hive/test/tests/box/box_base_test.dart
+++ b/hive/test/tests/box/box_base_test.dart
@@ -26,6 +26,9 @@ class _BoxBaseMock<E> extends BoxBaseImpl<E> with Mock {
           compactionStrategy,
           backend,
         );
+
+  @override
+  Future<void> flush() => Future.value();
 }
 
 _BoxBaseMock _openBoxBaseMock({
@@ -296,6 +299,7 @@ void main() {
         var keystore = MockKeystore();
 
         returnFutureVoid(when(() => backend.clear()));
+
         when(() => keystore.clear()).thenReturn(2);
 
         var box = _openBoxBaseMock(backend: backend, keystore: keystore);
@@ -400,6 +404,7 @@ void main() {
         var box = _openBoxBaseMock(backend: backend, keystore: keystore);
         returnFutureVoid(when(() => keystore.close()));
         returnFutureVoid(when(() => backend.close()));
+
         returnFutureVoid(when(() => backend.deleteFromDisk()));
 
         await box.close();

--- a/hive/test/tests/box/box_impl_test.dart
+++ b/hive/test/tests/box/box_impl_test.dart
@@ -110,6 +110,7 @@ void main() {
         );
 
         await box.putAll({'key1': 'value1', 'key2': 'value2'});
+        await box.flush();
         verifyInOrder([
           () => keystore.beginTransaction(frames),
           () => backend.writeFrames(frames),
@@ -189,6 +190,7 @@ void main() {
         );
 
         await box.deleteAll(['key1', 'key2']);
+        await box.flush();
         verifyInOrder([
           () => keystore.containsKey('key1'),
           () => keystore.containsKey('key2'),

--- a/hive/test/tests/box/lazy_box_impl_test.dart
+++ b/hive/test/tests/box/lazy_box_impl_test.dart
@@ -87,6 +87,7 @@ void main() {
         );
 
         await box.putAll({'key1': 'value1', 'key2': 'value2'});
+        await box.flush();
         verifyInOrder([
           () => backend.writeFrames([
                 Frame('key1', 'value1'),
@@ -152,6 +153,7 @@ void main() {
         );
 
         await box.deleteAll(['key1', 'key2']);
+        await box.flush();
         verifyInOrder([
           () => keystore.containsKey('key1'),
           () => keystore.containsKey('key2'),

--- a/hive/test/tests/frames.dart
+++ b/hive/test/tests/frames.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -158,7 +159,7 @@ void expectFrames(Iterable<Frame> f1, Iterable<Frame> f2) {
 
 void buildGoldens() async {
   Future<void> generate(String fileName, String varName,
-      Uint8List Function(Frame frame) transformer) async {
+      FutureOr<Uint8List> Function(Frame frame) transformer) async {
     var file = File('test/generated/$fileName.g.dart');
     await file.create();
     var code = StringBuffer();
@@ -166,7 +167,7 @@ void buildGoldens() async {
     code.writeln('final $varName = [');
     for (var frame in testFrames) {
       code.writeln('// ${frame.key}');
-      var bytes = transformer(frame);
+      var bytes = await transformer(frame);
       code.writeln('Uint8List.fromList(${bytes.toString()}),');
     }
     code.writeln('];');
@@ -188,9 +189,10 @@ void buildGoldens() async {
     writer.writeFrame(f, cipher: testCipher);
     return writer.toBytes();
   });
-  await generate('frame_values_encrypted', 'frameValuesBytesEncrypted', (f) {
-    var writer = BinaryWriterImpl(HiveImpl())
-      ..writeEncrypted(f.value, testCipher, writeTypeId: false);
+  await generate('frame_values_encrypted', 'frameValuesBytesEncrypted',
+      (f) async {
+    var writer = BinaryWriterImpl(HiveImpl());
+    await writer.writeEncrypted(f.value, testCipher, writeTypeId: false);
     return writer.toBytes();
   });
 }

--- a/hive/test/tests/mocks.dart
+++ b/hive/test/tests/mocks.dart
@@ -17,7 +17,10 @@ class MockBox<E> extends Mock implements Box<E> {}
 
 class MockChangeNotifier extends Mock implements ChangeNotifier {}
 
-class MockStorageBackend extends Mock implements StorageBackend {}
+class MockStorageBackend extends Mock implements StorageBackend {
+  @override
+  flush() async {}
+}
 
 class MockKeystore extends Mock implements Keystore {}
 

--- a/hive_flutter/.gitignore
+++ b/hive_flutter/.gitignore
@@ -28,4 +28,5 @@ migrate_working_dir/
 .dart_tool/
 .packages
 build/
+
 .flutter-plugins-dependencies

--- a/hive_flutter/lib/hive_flutter.dart
+++ b/hive_flutter/lib/hive_flutter.dart
@@ -11,6 +11,8 @@ import 'package:path_provider/path_provider.dart'
     if (dart.library.html) 'src/stub/path_provider.dart';
 
 export 'package:hive/hive.dart';
+export 'src/crypto/hive_aes_native_cbc_cipher.dart';
+export 'src/crypto/hive_aes_native_gcm_cipher.dart';
 
 part 'src/box_extensions.dart';
 part 'src/hive_extensions.dart';

--- a/hive_flutter/lib/src/crypto/extensions.dart
+++ b/hive_flutter/lib/src/crypto/extensions.dart
@@ -1,0 +1,11 @@
+import 'dart:typed_data';
+
+/// Not part of public API
+extension Uint8ListX on Uint8List {
+  /// Not part of public API
+  @pragma('vm:prefer-inline')
+  @pragma('dart2js:tryInline')
+  Uint8List view(int offset, int bytes) {
+    return Uint8List.view(buffer, offsetInBytes + offset, bytes);
+  }
+}

--- a/hive_flutter/lib/src/crypto/hive_aes_native_cbc_cipher.dart
+++ b/hive_flutter/lib/src/crypto/hive_aes_native_cbc_cipher.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:hive_flutter/src/crypto/extensions.dart';
+
+/// Multi-threaded cipher. Uses AES256 CBC
+///
+/// **IMPORTANT**: Setup required:
+/// https://pub.dev/packages/cryptography_flutter#getting-started
+///
+/// 1. add dependency to pubspec.yaml
+///
+/// ```yaml
+/// dependencies:
+///   cryptography_flutter: ^2.0.2
+/// ```
+///
+/// 2. enable native implementations
+///
+/// ```dart
+/// import 'package:cryptography_flutter/cryptography_flutter.dart';
+///
+/// void main() {
+///   // Enable Flutter cryptography
+///   FlutterCryptography.enable();
+///
+///   // ....
+/// }
+/// ```
+///
+/// This implementation extends the [HiveCipher] with native AES implementations
+/// on Android, iOS, macOS as well as on web using [AesCbc].
+///
+/// This may highly decrease the delay in the event loop of the Flutter
+/// application. A disadvantage is the fact that each computation takes a bit
+/// longer than its main-thread equivalent because spawning a new thread
+/// takes its time.
+class HiveAesNativeCbcCipher extends HiveAesCipher {
+  late final List<int> _key;
+  final Completer<SecretKey> secretKey = Completer();
+
+  HiveAesNativeCbcCipher(List<int> key)
+      : assert(key.length == 32 && key.every((it) => it > 0 || it <= 255),
+            'The encryption key has to be a 32 byte (256 bit) array.'),
+        _key = key,
+        super(key) {
+    _algorithm.newSecretKeyFromBytes(_key).then(secretKey.complete);
+  }
+
+  /// AES-CBC with 256 bit keys
+  AesCbc get _algorithm => AesCbc.with256bits(macAlgorithm: MacAlgorithm.empty);
+
+  @override
+  Future<int> decrypt(Uint8List inp, int inpOff, int inpLength, Uint8List out,
+      int outOff) async {
+    final bytes = inp.view(inpOff, inpLength);
+
+    /// preparing the [SecretBox] with the range from the [inpOff] in the [inp]
+    final secretBox =
+        SecretBox.fromConcatenation(bytes, nonceLength: 16, macLength: 0);
+
+    /// decrypting
+    final result =
+        await _algorithm.decrypt(secretBox, secretKey: await secretKey.future);
+
+    /// save the clear text in the [out]
+    out.setRange(outOff, outOff + result.length, result);
+
+    /// return the clear text length as new offset
+    return result.length;
+  }
+
+  @override
+  Future<int> encrypt(Uint8List inp, int inpOff, int inpLength, Uint8List out,
+      int outOff) async {
+    /// generating new nonce / iv
+    final nonce = _algorithm.newNonce();
+
+    /// encrypt the next 16 bytes of the [inp] starting from [inpOff]
+    final secretBox = await _algorithm.encrypt(
+      inp.view(inpOff, inpLength),
+      secretKey: await secretKey.future,
+      nonce: nonce,
+    );
+
+    assert(secretBox.mac.bytes.isEmpty && secretBox.nonce.length == 16,
+        'The AesCbc nonce / iv and mac should be 16 / 0 bytes long.');
+
+    /// concentrating the encrypted text, nonce / iv and mac
+    final concentration = secretBox.concatenation();
+
+    /// save the encrypted bytes in the [out]
+    final outOffset = outOff + concentration.length;
+    if (outOffset > out.length) {
+      final previousOut = Uint8List.fromList(out);
+      out = Uint8List(outOffset)..setRange(0, previousOut.length, previousOut);
+    }
+    out.setRange(outOff, outOffset, concentration);
+
+    return concentration.length;
+  }
+}

--- a/hive_flutter/lib/src/crypto/hive_aes_native_gcm_cipher.dart
+++ b/hive_flutter/lib/src/crypto/hive_aes_native_gcm_cipher.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:hive_flutter/src/crypto/extensions.dart';
+
+/// Multi-threaded cipher. Uses AES256 GCM
+///
+/// **IMPORTANT**: Setup required:
+/// https://pub.dev/packages/cryptography_flutter#getting-started
+///
+/// 1. add dependency to pubspec.yaml
+///
+/// ```yaml
+/// dependencies:
+///   cryptography_flutter: ^2.0.2
+/// ```
+///
+/// 2. enable native implementations
+///
+/// ```dart
+/// import 'package:cryptography_flutter/cryptography_flutter.dart';
+///
+/// void main() {
+///   // Enable Flutter cryptography
+///   FlutterCryptography.enable();
+///
+///   // ....
+/// }
+/// ```
+///
+/// This implementation extends the [HiveCipher] with native AES implementations
+/// on Android, iOS, macOS as well as on web using [AesGcm].
+///
+/// This may highly decrease the delay in the event loop of the Flutter
+/// application. A disadvantage is the fact that each computation takes a bit
+/// longer than its main-thread equivalent because spawning a new thread
+/// takes its time.
+class HiveAesNativeGcmCipher extends HiveAesCipher {
+  late final List<int> _key;
+  final Completer<SecretKey> secretKey = Completer();
+
+  HiveAesNativeGcmCipher(List<int> key)
+      : assert(key.length == 32 && key.every((it) => it > 0 || it <= 255),
+            'The encryption key has to be a 32 byte (256 bit) array.'),
+        _key = key,
+        super(key) {
+    _algorithm.newSecretKeyFromBytes(_key).then(secretKey.complete);
+  }
+
+  /// AES-GCM with 256 bit keys
+  AesGcm get _algorithm => AesGcm.with256bits(nonceLength: 16);
+
+  @override
+  Future<int> decrypt(Uint8List inp, int inpOff, int inpLength, Uint8List out,
+      int outOff) async {
+    final bytes = inp.view(inpOff, inpLength);
+
+    /// preparing the [SecretBox] with the range from the [inpOff] in the [inp]
+    final secretBox =
+        SecretBox.fromConcatenation(bytes, nonceLength: 16, macLength: 16);
+
+    /// decrypting
+    final result =
+        await _algorithm.decrypt(secretBox, secretKey: await secretKey.future);
+
+    /// save the clear text in the [out]
+    out.setRange(outOff, outOff + result.length, result);
+
+    /// return the clear text length as new offset
+    return result.length;
+  }
+
+  @override
+  Future<int> encrypt(Uint8List inp, int inpOff, int inpLength, Uint8List out,
+      int outOff) async {
+    /// generating new nonce / iv
+    final nonce = _algorithm.newNonce();
+
+    /// encrypt the next 16 bytes of the [inp] starting from [inpOff]
+    final secretBox = await _algorithm.encrypt(
+      inp.view(inpOff, inpLength),
+      secretKey: await secretKey.future,
+      nonce: nonce,
+    );
+
+    assert(secretBox.mac.bytes.length == 16 && secretBox.nonce.length == 16,
+        'The AesGcm nonce / iv and mac should be 16 bytes long.');
+
+    /// concentrating the encrypted text, nonce / iv and mac
+    final concentration = secretBox.concatenation();
+
+    /// save the encrypted bytes in the [out]
+    final outOffset = outOff + concentration.length;
+    if (outOffset > out.length) {
+      final previousOut = Uint8List.fromList(out);
+      out = Uint8List(outOffset)..setRange(0, previousOut.length, previousOut);
+    }
+    out.setRange(outOff, outOffset, concentration);
+
+    return concentration.length;
+  }
+}

--- a/hive_flutter/pubspec.yaml
+++ b/hive_flutter/pubspec.yaml
@@ -11,12 +11,14 @@ dependencies:
   flutter:
     sdk: flutter
 
+  cryptography: ^2.0.5
   hive: ^2.2.1
   path_provider: ^2.0.10
-  path: ^1.8.2
+  path: ^1.8.1
 
 dev_dependencies:
   test: ^1.21.1
   lints: ">=1.0.0"
   mockito: ^5.2.0
   build_runner: ^2.1.11
+

--- a/hive_flutter/test/crypto/directory.dart
+++ b/hive_flutter/test/crypto/directory.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+import 'dart:math';
+import 'package:path/path.dart' as path;
+
+String tempPath =
+    path.join(Directory.current.path, '.dart_tool', 'test', 'tmp');
+
+Future<Directory> getTempDir() async {
+  final random = Random();
+  var name = random.nextInt(pow(2, 32) as int);
+  var dir = Directory(path.join(tempPath, '${name}_tmp'));
+  if (await dir.exists()) {
+    await dir.delete(recursive: true);
+  }
+  await dir.create(recursive: true);
+  return dir;
+}
+
+const boxName = 'test';

--- a/hive_flutter/test/crypto/hive_aes_native_cipher_test.dart
+++ b/hive_flutter/test/crypto/hive_aes_native_cipher_test.dart
@@ -1,0 +1,38 @@
+import 'dart:math';
+
+import 'package:hive_flutter/adapters.dart';
+import 'package:hive_flutter/src/crypto/hive_aes_native_cbc_cipher.dart';
+import 'package:test/test.dart';
+
+import 'directory.dart';
+
+void main() {
+  group('HiveAesNativeCbcCipher', () {
+    late HiveAesNativeCbcCipher cipher;
+    late Box box;
+    late List<int> message;
+
+    setUp(() async {
+      final random = Random.secure();
+      cipher = HiveAesNativeCbcCipher(
+        List.generate(32, (index) => random.nextInt(255)),
+      );
+
+      var dir = await getTempDir();
+      Hive.init(dir.path);
+
+      box = await Hive.openBox<List<int>>(boxName, encryptionCipher: cipher);
+
+      message = List.generate(64, (index) => random.nextInt(255));
+    });
+    test('encrypt()', () async {
+      final index = await box.add(message);
+
+      await box.close();
+
+      box = await Hive.openBox<List<int>>(boxName, encryptionCipher: cipher);
+      final value = box.getAt(index);
+      expect(value, message);
+    });
+  });
+}

--- a/hive_flutter/test/crypto/hive_aes_native_gcm_cipher_test.dart
+++ b/hive_flutter/test/crypto/hive_aes_native_gcm_cipher_test.dart
@@ -1,0 +1,38 @@
+import 'dart:math';
+
+import 'package:hive_flutter/adapters.dart';
+import 'package:hive_flutter/src/crypto/hive_aes_native_gcm_cipher.dart';
+import 'package:test/test.dart';
+
+import 'directory.dart';
+
+void main() {
+  group('HiveAesNativeGcmCipher', () {
+    late HiveAesNativeGcmCipher cipher;
+    late Box box;
+    late List<int> message;
+
+    setUp(() async {
+      final random = Random.secure();
+      cipher = HiveAesNativeGcmCipher(
+        List.generate(32, (index) => random.nextInt(255)),
+      );
+
+      var dir = await getTempDir();
+      Hive.init(dir.path);
+
+      box = await Hive.openBox<List<int>>(boxName, encryptionCipher: cipher);
+
+      message = List.generate(64, (index) => random.nextInt(255));
+    });
+    test('encrypt()', () async {
+      final index = await box.add(message);
+
+      await box.close();
+
+      box = await Hive.openBox<List<int>>(boxName, encryptionCipher: cipher);
+      final value = box.getAt(index);
+      expect(value, message);
+    });
+  });
+}


### PR DESCRIPTION
- extend default buffer size (thanks to @nico-famedly)
- allow HiveCipher to asynchronously perform crypto
- implement HiveAesThreadedCipher for Hive Flutter
- fix missing file in .gitignore

In theory, no public API should be made incompatible here as HIveCipher
was simply converted from `T Function()` to `FutureOr<T> Function()`.

The idea behind the asynchronous operation is

a) multithreading using e.g. the `compute()` function in Flutter or
b) platform-native implementations making use of hardware-accelerated
cryptographic implementations.

CC: @nico-famedly maybe you like to try out this?

Signed-off-by: TheOneWithTheBraid <the-one@with-the-braid.cf>