### PR TITLE
feat: made resetAdapters public

### DIFF
--- a/hive/lib/src/hive.dart
+++ b/hive/lib/src/hive.dart
@@ -76,6 +76,9 @@ abstract class HiveInterface implements TypeRegistry {
   ///
   /// NOTE: [resetAdapters] also clears the default adapters registered
   /// by Hive.
+  ///
+  /// WARNING: This method is only intended to be used for integration and unit tests
+  /// and SHOULD not be used in production code.
   void resetAdapters();
 }
 

--- a/hive/lib/src/hive.dart
+++ b/hive/lib/src/hive.dart
@@ -72,7 +72,7 @@ abstract class HiveInterface implements TypeRegistry {
 
   /// Clears all registered adapters.
   ///
-  /// To register an adapter use [TypeRegistry.registerAdapter].
+  /// To register an adapter use [registerAdapter].
   ///
   /// NOTE: [resetAdapters] also clears the default adapters registered
   /// by Hive.

--- a/hive/lib/src/hive.dart
+++ b/hive/lib/src/hive.dart
@@ -79,6 +79,7 @@ abstract class HiveInterface implements TypeRegistry {
   ///
   /// WARNING: This method is only intended to be used for integration and unit tests
   /// and SHOULD not be used in production code.
+  @visibleForTesting
   void resetAdapters();
 }
 

--- a/hive/lib/src/hive.dart
+++ b/hive/lib/src/hive.dart
@@ -71,9 +71,9 @@ abstract class HiveInterface implements TypeRegistry {
   Future<bool> boxExists(String name, {String? path});
 
   /// Clears all registered adapters.
-  /// 
+  ///
   /// To register an adapter use [TypeRegistry.registerAdapter].
-  /// 
+  ///
   /// NOTE: [resetAdapters] also clears the default adapters registered
   /// by Hive.
   void resetAdapters();

--- a/hive/lib/src/hive.dart
+++ b/hive/lib/src/hive.dart
@@ -69,6 +69,14 @@ abstract class HiveInterface implements TypeRegistry {
 
   /// Checks if a box exists
   Future<bool> boxExists(String name, {String? path});
+
+  /// Clears all registered adapters.
+  /// 
+  /// To register an adapter use [TypeRegistry.registerAdapter].
+  /// 
+  /// NOTE: [resetAdapters] also clears the default adapters registered
+  /// by Hive.
+  void resetAdapters();
 }
 
 ///

--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -255,4 +255,7 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
     return await _manager.boxExists(
         lowerCaseName, path ?? homePath, collection);
   }
+
+  
+
 }

--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -255,7 +255,4 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
     return await _manager.boxExists(
         lowerCaseName, path ?? homePath, collection);
   }
-
-  
-
 }

--- a/hive/lib/src/registry/type_registry_impl.dart
+++ b/hive/lib/src/registry/type_registry_impl.dart
@@ -132,7 +132,6 @@ class TypeRegistryImpl implements TypeRegistry {
     return findAdapterForTypeId(typeId) != null;
   }
 
-  /// Not part of public API
   void resetAdapters() {
     _typeAdapters.clear();
   }

--- a/hive/test/tests/hive_impl_test.dart
+++ b/hive/test/tests/hive_impl_test.dart
@@ -9,6 +9,19 @@ import 'package:test/test.dart';
 
 import 'common.dart';
 
+class _TestAdapter extends TypeAdapter<int> {
+  _TestAdapter([this.typeId = 0]);
+
+  @override
+  final int typeId;
+
+  @override
+  int read(_) => 5;
+
+  @override
+  void write(_, __) {}
+}
+
 void main() {
   group('HiveImpl', () {
     Future<HiveImpl> initHive() async {
@@ -314,6 +327,25 @@ void main() {
         await hive.deleteBoxFromDisk('testBox1');
         expect(await hive.boxExists('testBox1'), false);
         await hive.close();
+      });
+    });
+
+    group('.resetAdapters()', () {
+      test('returns normally', () async {
+        final hive = await initHive();
+        expect(hive.resetAdapters, returnsNormally);
+      });
+
+       test('clears an adapter', () async {
+        final hive = await initHive();
+        final adapter = _TestAdapter(1);
+
+        expect(hive.isAdapterRegistered(adapter.typeId), isFalse);
+        hive.registerAdapter(adapter);
+        expect(hive.isAdapterRegistered(adapter.typeId), isTrue);
+
+        hive.resetAdapters();
+        expect(hive.isAdapterRegistered(adapter.typeId), isFalse);
       });
     });
   });

--- a/hive/test/tests/hive_impl_test.dart
+++ b/hive/test/tests/hive_impl_test.dart
@@ -336,7 +336,7 @@ void main() {
         expect(hive.resetAdapters, returnsNormally);
       });
 
-       test('clears an adapter', () async {
+      test('clears an adapter', () async {
         final hive = await initHive();
         final adapter = _TestAdapter(1);
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

## Breaking Changes

NO

## Description

Makes the `clearAdapters` part of the public API.

When configuring integration tests one usually does the following:

```dart
import 'package:flutter_test/flutter_test.dart';
import 'package:integration_test/integration_test.dart';
import 'package:my_app/main/main.dart' as app;

void main() {
  IntegrationTestWidgetsFlutterBinding.ensureInitialized().framePolicy =
      LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;

  group('login', () {
    setUp(app.main); // This setup registers the adapters.

    testWidgets('unsuccessful when missing username', (tester) async {
      // Some logic here.
    });

    testWidgets('unsuccessful when missing password', (tester) async {
      // Some logic here.
    });
  });
}
```

However,  only the test that runs first succeeds since when the second test aims to `registerAdapter` a `HiveError` is thrown since the adapter already exists.

```dart
// main.dart
...
  await Hive.initFlutter();
  Hive.registerAdapter(MobileSettingsAdapter());
...
```

There are workarounds to solve the above, like for example making use of  the `override` flag in `registerAdapter` or checking if the adapter has been already registered before registering one. I dislike these approaches since they force to write logic in the codebase that is only used for and during testing purposes. 

Ideally, I would prefer if one could `tearDown` and `clearAdapters`. And with the changes in this PR, one can `tearDown` and `clearAdapters`.

I'm open to other suggestions or existing solutions that only modify the test file.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore