### PR TITLE
fix: Remove print from deleteBoxFromDisk

### DIFF
--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -226,7 +226,6 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
       {String? path, String? collection}) async {
     var lowerCaseName = name.toLowerCase();
     var box = _boxes[lowerCaseName];
-    print(box);
     if (box != null) {
       await box.deleteFromDisk();
     } else {


### PR DESCRIPTION
This print looks unnecessary and spams "null" into our production app