### PR TITLE
Allow users to disable lockfiles at their own risk

### DIFF
--- a/hive/lib/src/backend/vm/storage_backend_vm.dart
+++ b/hive/lib/src/backend/vm/storage_backend_vm.dart
@@ -8,6 +8,7 @@ import 'package:hive/src/binary/binary_reader_impl.dart';
 import 'package:hive/src/binary/binary_writer_impl.dart';
 import 'package:hive/src/binary/frame.dart';
 import 'package:hive/src/box/keystore.dart';
+import 'package:hive/src/hive_impl.dart';
 import 'package:hive/src/io/buffered_file_reader.dart';
 import 'package:hive/src/io/buffered_file_writer.dart';
 import 'package:hive/src/io/frame_io_helper.dart';
@@ -78,7 +79,9 @@ class StorageBackendVm extends StorageBackend {
     this.registry = registry;
 
     lockRaf = await _lockFile.open(mode: FileMode.write);
-    await lockRaf.lock();
+    if ((Hive as HiveImpl).useLocks) {
+      await lockRaf.lock();
+    }
 
     int recoveryOffset;
     if (!lazy) {

--- a/hive/lib/src/hive.dart
+++ b/hive/lib/src/hive.dart
@@ -5,10 +5,22 @@ abstract class HiveInterface implements TypeRegistry {
   /// Initialize Hive by giving it a home directory.
   ///
   /// (Not necessary in the browser)
+  ///
+  /// The [useLocks] parameter can be used to turn off lockfiles for the
+  /// database. Locks are used to prevent other processes from opening the
+  /// database and in turn protect the database from corruption. If you turn
+  /// this off, you need to externally synchronize accesses to the database.
+  /// There is no performance benefit from disabling locks. The only benefit is
+  /// that some platforms don't allow you to suspend while holding a lock for a
+  /// file in a shared folder (i.e. on iOS, if you move the database to a
+  /// shared container). If your app isn't crashing because it holds a lock
+  /// during suspension and you don't know that you need this feature and don't
+  /// understand the consequences, don't turn locking off.
   void init(
     String? path, {
     HiveStorageBackendPreference backendPreference =
         HiveStorageBackendPreference.native,
+    bool useLocks = true,
   });
 
   /// Opens a box.

--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -31,6 +31,9 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
   @visibleForTesting
   String? homePath;
 
+  @visibleForTesting
+  bool useLocks = true;
+
   /// Not part of public API
   HiveImpl() {
     _registerDefaultAdapters();
@@ -52,9 +55,11 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
     String? path, {
     HiveStorageBackendPreference backendPreference =
         HiveStorageBackendPreference.native,
+    bool useLocks = true,
   }) {
     homePath = path;
     _managerOverride = BackendManager.select(backendPreference);
+    this.useLocks = useLocks;
   }
 
   Future<BoxBase<E>> _openBox<E>(


### PR DESCRIPTION
This is somewhat of a workaround for an iOS issue we ran into. We use hive as the database for a chat application. To be able to show notifications when the app is in the background we use a Notification Service Extension and give the NSE access to the database, so that it can read the room names and such from the database. (We implemented a barebones hive reader in Swift for that.)

Since the database is only opened read only while the app is suspended and we only read data from it and immediately close it again, we don't really have any concurrency issues. However, iOS unconditionally kills your application if it has any lockfiles open in a directory, that another process could access. Since we share a container with the NSE, our app gets killed any time it is backgrounded. There might be other ways to solve this, but since we already make sure the database can only be written to by one process, I think disabling the locks is the best option, since they are not needed in our case. Another option would be to lock more granularly or prepend an SQLite file header, but those seem like worse options to me.

For reference, here is a an issue about how SQLCipher ran into that
issue: https://github.com/sqlcipher/sqlcipher/issues/255