### PR TITLE
chore: Use `unawaited` instead of ignoring the lint

### DIFF
--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -117,8 +117,7 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
         completer.completeError(error, stackTrace);
         rethrow;
       } finally {
-        // ignore: unawaited_futures
-        _openingBoxes.remove(TupleBoxKey(name, collection));
+        unawaited(_openingBoxes.remove(TupleBoxKey(name, collection)));
       }
     }
   }


### PR DESCRIPTION
Using `unawaited` provides more context about the purpose of not awaiting a future and it has no effects. In this commit, I simply deleted the "ignore lint" comment and wrapped the `remove` function in `unawaited`.

Following is the implementation of `unawaited` (from "dart:async" package):
```dart
/// Explicitly ignores a future.
///
/// Not all futures need to be awaited.
/// The Dart linter has an optional ["unawaited futures" lint](https://dart-lang.github.io/linter/lints/unawaited_futures.html)
/// which enforces that potential futures
/// (expressions with a static type of [Future] or `Future?`)
/// in asynchronous functions are handled *somehow*.
/// If a particular future value doesn't need to be awaited,
/// you can call `unawaited(...)` with it, which will avoid the lint,
/// simply because the expression no longer has type [Future].
/// Using `unawaited` has no other effect.
/// You should use `unawaited` to convey the *intention* of
/// deliberately not waiting for the future.
///
/// If the future completes with an error,
/// it was likely a mistake to not await it.
/// That error will still occur and will be considered unhandled
/// unless the same future is awaited (or otherwise handled) elsewhere too.
/// Because of that, `unawaited` should only be used for futures that
/// are *expected* to complete with a value.
/// You can use [FutureExtensions.ignore] if you also don't want to know
/// about errors from this future.
@Since("2.15")
void unawaited(Future<void>? future) {}
```