### PR TITLE
Updated initFlutter function like hive.init

### DIFF
--- a/hive_flutter/CHANGELOG.md
+++ b/hive_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.0-dev
+
+- Changed initFlutter function like Hive init. Changes could break older versions of app so bumped it to 3.0.0-dev.
 ## 2.0.0-dev
 
 - Threaded AesCipher support

--- a/hive_flutter/lib/hive_flutter.dart
+++ b/hive_flutter/lib/hive_flutter.dart
@@ -5,8 +5,6 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hive/hive.dart';
-import 'package:path/path.dart' if (dart.library.html) 'src/stub/path.dart'
-    as path_helper;
 import 'package:path_provider/path_provider.dart'
     if (dart.library.html) 'src/stub/path_provider.dart';
 

--- a/hive_flutter/lib/src/hive_extensions.dart
+++ b/hive_flutter/lib/src/hive_extensions.dart
@@ -4,17 +4,21 @@ part of hive_flutter;
 extension HiveX on HiveInterface {
   /// Initializes Hive with the path from [getApplicationDocumentsDirectory].
   ///
-  /// You can provide a [subDir] where the boxes should be stored.
   Future<void> initFlutter(
-      [String? subDir,
-      HiveStorageBackendPreference backendPreference =
-          HiveStorageBackendPreference.native]) async {
+    String? customPath, {
+    HiveStorageBackendPreference backendPreference =
+        HiveStorageBackendPreference.native,
+  }) async {
     WidgetsFlutterBinding.ensureInitialized();
 
     String? path;
     if (!kIsWeb) {
-      var appDir = await getApplicationDocumentsDirectory();
-      path = path_helper.join(appDir.path, subDir);
+      if (customPath != null) {
+        path = customPath;
+      } else {
+        var appDir = await getApplicationDocumentsDirectory();
+        path = appDir.path;
+      }
     }
 
     init(

--- a/hive_flutter/pubspec.yaml
+++ b/hive_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hive_flutter
 description: Extension for Hive. Makes it easier to use Hive in Flutter apps.
-version: 2.0.0-dev
+version: 3.0.0-dev
 homepage: https://github.com/hivedb/hive/tree/master/hive_flutter
 documentation: https://docs.hivedb.dev/
 


### PR DESCRIPTION
Changed body of initFlutter like hive.init as by default it always place hive in documents directory but sometimes a database is needed to be hidden from users , for that now users can user ApplicationSupportDirectory.
Or other path can be chosen.

```dart
Future<void> initFlutter(
    String? customPath, {
    HiveStorageBackendPreference backendPreference =
        HiveStorageBackendPreference.native,
  }) async {
    WidgetsFlutterBinding.ensureInitialized();

    String? path;
    if (!kIsWeb) {
      if (customPath != null) {
        path = customPath;
      } else {
        var appDir = await getApplicationDocumentsDirectory();
        path = appDir.path;
      }
    }

    init(
      path,
      backendPreference: backendPreference,
    );
  }
```