### PR TITLE
Close the file if the lock fails

### DIFF
--- a/hive/lib/src/backend/vm/storage_backend_vm.dart
+++ b/hive/lib/src/backend/vm/storage_backend_vm.dart
@@ -80,7 +80,13 @@ class StorageBackendVm extends StorageBackend {
 
     lockRaf = await _lockFile.open(mode: FileMode.write);
     if ((Hive as HiveImpl).useLocks) {
-      await lockRaf.lock();
+      try {
+        await lockRaf.lock();
+      } catch (e) {
+        // Close the opened file to not leave it blocked for other purposes.
+        await lockRaf.close();
+        rethrow;
+      }
     }
 
     int recoveryOffset;


### PR DESCRIPTION
It seems that at least on Windows, not closing the file leads to not being able to use it elsewhere.
This is needed for some use cases of [hive_multiisolate](https://github.com/TheCarpetMerchant/hive_multiisolate).

Tests ran fine, just some long ones failed due to timeout, I blame my old disk.