### PR TITLE
Allow non-ASCII box names

### DIFF
--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -74,8 +74,8 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
     String? collection,
   ) async {
     assert(path == null || backend == null);
-    assert(name.length <= 255 && name.isAscii,
-        'Box names need to be ASCII Strings with a max length of 255.');
+    assert(name.length <= 255,
+        'Box names need to be a max length of 255.');
     name = name.toLowerCase();
     if (isBoxOpen(name)) {
       if (lazy) {


### PR DESCRIPTION
Shouldn't this check be removed? 

https://github.com/hivedb/hive/blob/1451845d080007d8e9169798b4dda81cbd6c08fd/hive/lib/src/hive_impl.dart#L77-L78

Can't use `Future<BoxBase<E>> _openBox<E>` due to this with non-ASCII string. Fixed after removing this. 