### PR TITLE
Pass through useLocks parameter for hive collections

### DIFF
--- a/hive/lib/src/box_collection/box_collection.dart
+++ b/hive/lib/src/box_collection/box_collection.dart
@@ -31,12 +31,13 @@ class BoxCollection implements implementation.BoxCollection {
     String? path,
     @Deprecated('Use [cipher] instead') HiveCipher? key,
     HiveCipher? cipher,
+    bool useLocks = true,
   }) async {
     // compatibility for [key]
     cipher ??= key;
 
     if (!_hiveInit) {
-      Hive.init(path ?? './');
+      Hive.init(path ?? './', useLocks: useLocks);
       _hiveInit = true;
     }
     final names = boxNames..add('bad_keys');

--- a/hive/lib/src/box_collection/box_collection_stub.dart
+++ b/hive/lib/src/box_collection/box_collection_stub.dart
@@ -10,6 +10,7 @@ abstract class BoxCollection {
     Set<String> boxNames, {
     String? path,
     HiveCipher? key,
+    bool useLocks = true,
   }) {
     throw UnimplementedError();
   }


### PR DESCRIPTION
Makes `useLocks` work also with collections.