### PR TITLE
Draft: chore: use existing open file in Frame Helper

### DIFF
--- a/hive/lib/src/backend/vm/storage_backend_vm.dart
+++ b/hive/lib/src/backend/vm/storage_backend_vm.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer';
 import 'dart:io';
 
 import 'package:hive/hive.dart';
@@ -38,7 +39,7 @@ class StorageBackendVm extends StorageBackend {
 
   /// Not part of public API
   @visibleForTesting
-  late RandomAccessFile lockRaf;
+  RandomAccessFile? lockRaf;
 
   /// Not part of public API
   @visibleForTesting
@@ -78,28 +79,38 @@ class StorageBackendVm extends StorageBackend {
       TypeRegistry registry, Keystore keystore, bool lazy) async {
     this.registry = registry;
 
-    lockRaf = await _lockFile.open(mode: FileMode.write);
     if ((Hive as HiveImpl).useLocks) {
+      final lockRaf = this.lockRaf = await _lockFile.open(mode: FileMode.write);
       await lockRaf.lock();
     }
 
-    int recoveryOffset;
-    if (!lazy) {
-      recoveryOffset =
-          await _frameHelper.framesFromFile(path, keystore, registry, _cipher);
-    } else {
-      recoveryOffset = await _frameHelper.keysFromFile(path, keystore, _cipher);
-    }
-
-    if (recoveryOffset != -1) {
-      if (_crashRecovery) {
-        print('Recovering corrupted box.');
-        await writeRaf.truncate(recoveryOffset);
-        await writeRaf.setPosition(recoveryOffset);
-        writeOffset = recoveryOffset;
+    try {
+      int recoveryOffset;
+      if (!lazy) {
+        recoveryOffset = await _frameHelper.framesFromFile(
+            readRaf, keystore, registry, _cipher);
       } else {
-        throw HiveError('Wrong checksum in hive file. Box may be corrupted.');
+        recoveryOffset =
+            await _frameHelper.keysFromFile(readRaf, keystore, _cipher);
       }
+
+      if (recoveryOffset != -1) {
+        if (_crashRecovery) {
+          print('Recovering corrupted box.');
+          await writeRaf.truncate(recoveryOffset);
+          await writeRaf.setPosition(recoveryOffset);
+          writeOffset = recoveryOffset;
+        } else {
+          throw HiveError('Wrong checksum in hive file. Box may be corrupted.');
+        }
+      }
+    } catch (e, s) {
+      log(
+        'Error checking hive recovery offset',
+        error: e,
+        stackTrace: s,
+        name: 'hive',
+      );
     }
   }
 
@@ -217,7 +228,7 @@ class StorageBackendVm extends StorageBackend {
     await readRaf.close();
     await writeRaf.close();
 
-    await lockRaf.close();
+    await lockRaf?.close();
     await _lockFile.delete();
   }
 

--- a/hive/test/tests/backend/memory/random_access_buffer_test.dart
+++ b/hive/test/tests/backend/memory/random_access_buffer_test.dart
@@ -4,7 +4,6 @@ import 'package:hive/src/binary/frame.dart';
 import 'package:hive/src/registry/type_registry_impl.dart';
 import 'package:test/test.dart';
 
-
 void main() {
   group('RandomAccessBuffer', () {
     test('empty random access buffer', () {

--- a/hive/test/tests/backend/vm/storage_backend_vm_test.dart
+++ b/hive/test/tests/backend/vm/storage_backend_vm_test.dart
@@ -252,8 +252,7 @@ void main() {
             .thenAnswer((i) => Future.value(writeRaf));
         when(() => writeRaf.writeFrom(bytes))
             .thenAnswer((i) => Future.value(writeRaf));
-        when(() => writeRaf.flush())
-            .thenAnswer((i) => Future.value(writeRaf));
+        when(() => writeRaf.flush()).thenAnswer((i) => Future.value(writeRaf));
 
         var backend = _getBackend(writeRaf: writeRaf)
           // The registry needs to be initialized before writing values, and

--- a/hive/test/tests/io/frame_io_helper_test.dart
+++ b/hive/test/tests/io/frame_io_helper_test.dart
@@ -23,12 +23,12 @@ class _FrameIoHelperTest extends FrameIoHelper {
   _FrameIoHelperTest(this.bytes);
 
   @override
-  Future<RandomAccessFile> openFile(String path) async {
+  Future<RandomAccessFile> overridableRAF(RandomAccessFile raf) async {
     return getTempRaf(bytes);
   }
 
   @override
-  Future<Uint8List> readFile(String path) async {
+  Future<Uint8List> overridableReadFile(RandomAccessFile raf) async {
     return bytes;
   }
 }
@@ -39,8 +39,8 @@ void main() {
       test('frame', () async {
         var keystore = Keystore.debug();
         var ioHelper = _FrameIoHelperTest(_getBytes(frameBytes));
-        var recoveryOffset =
-            await ioHelper.keysFromFile('null', keystore, null);
+        var recoveryOffset = await ioHelper.keysFromFile(
+            await getTempRaf(const []), keystore, null);
         expect(recoveryOffset, -1);
 
         var testKeystore = Keystore.debug(
@@ -53,8 +53,8 @@ void main() {
       test('encrypted', () async {
         var keystore = Keystore.debug();
         var ioHelper = _FrameIoHelperTest(_getBytes(frameBytesEncrypted));
-        var recoveryOffset =
-            await ioHelper.keysFromFile('null', keystore, testCipher);
+        var recoveryOffset = await ioHelper.keysFromFile(
+            await getTempRaf(const []), keystore, testCipher);
         expect(recoveryOffset, -1);
 
         var testKeystore = Keystore.debug(
@@ -73,8 +73,8 @@ void main() {
       test('frame', () async {
         var keystore = Keystore.debug();
         var ioHelper = _FrameIoHelperTest(_getBytes(frameBytes));
-        var recoveryOffset =
-            await ioHelper.framesFromFile('null', keystore, testRegistry, null);
+        var recoveryOffset = await ioHelper.framesFromFile(
+            await getTempRaf(const []), keystore, testRegistry, null);
         expect(recoveryOffset, -1);
 
         var testKeystore = Keystore.debug(
@@ -88,7 +88,7 @@ void main() {
         var keystore = Keystore.debug();
         var ioHelper = _FrameIoHelperTest(_getBytes(frameBytesEncrypted));
         var recoveryOffset = await ioHelper.framesFromFile(
-            'null', keystore, testRegistry, testCipher);
+            await getTempRaf(const []), keystore, testRegistry, testCipher);
         expect(recoveryOffset, -1);
 
         var testKeystore = Keystore.debug(


### PR DESCRIPTION
- use existing read Random Access File in FrameIOHelper
- avoid conflicts opening the hive file on some filesystems

Meant as draft for initial tests, please don't merge yet.