### PR TITLE
Prevent adding events to closed stream controller

### DIFF
--- a/hive/lib/src/box/change_notifier.dart
+++ b/hive/lib/src/box/change_notifier.dart
@@ -17,7 +17,7 @@ class ChangeNotifier {
 
   /// Not part of public API
   void notify(Frame frame) {
-    if (_streamController.isClosed) {
+    if (!_streamController.isClosed) {
       _streamController.add(BoxEvent(frame.key, frame.value, frame.deleted));
     }
   }

--- a/hive/lib/src/box/change_notifier.dart
+++ b/hive/lib/src/box/change_notifier.dart
@@ -17,7 +17,9 @@ class ChangeNotifier {
 
   /// Not part of public API
   void notify(Frame frame) {
-    _streamController.add(BoxEvent(frame.key, frame.value, frame.deleted));
+    if (_streamController.isClosed) {
+      _streamController.add(BoxEvent(frame.key, frame.value, frame.deleted));
+    }
   }
 
   /// Not part of public API


### PR DESCRIPTION
Resolves #1034

I have same issue using following code:

``` dart

final box = await Hive.openLazyBox('local');
await box.clear();
await box.close();

```