### PR TITLE
Added `deleteAllAt()` to remove list of indices

### DIFF
--- a/hive/lib/src/box/box_base.dart
+++ b/hive/lib/src/box/box_base.dart
@@ -134,6 +134,14 @@ abstract class BoxBase<E> {
     bool notify = true,
   });
 
+  /// Deletes all the given [indexes] from the box.
+  ///
+  /// If an index does not exist, it is skipped.
+  Future<void> deleteAllAt(
+    Iterable<int> indexes, {
+    bool notify = true,
+  });
+
   /// Deletes all the given [keys] from the box.
   ///
   /// If a key does not exist, it is skipped.

--- a/hive/lib/src/box/box_base_impl.dart
+++ b/hive/lib/src/box/box_base_impl.dart
@@ -164,21 +164,6 @@ abstract class BoxBaseImpl<E> implements BoxBase<E> {
   }
 
   @override
-  Future<void> deleteAllAt(
-    Iterable<int> indexes, {
-    bool notify = true,
-  }) async {
-    for (var index in indexes.toList()..sort((a, b) => b.compareTo(a))) {
-      try {
-        deleteAt(index, notify: notify);
-      } catch (e) {
-        // Ignore errors
-      }
-    }
-    return;
-  }
-
-  @override
   Future<int> clear({bool notify = true}) async {
     checkOpen();
 

--- a/hive/lib/src/box/box_base_impl.dart
+++ b/hive/lib/src/box/box_base_impl.dart
@@ -164,6 +164,21 @@ abstract class BoxBaseImpl<E> implements BoxBase<E> {
   }
 
   @override
+  Future<void> deleteAllAt(
+    Iterable<int> indexes, {
+    bool notify = true,
+  }) async {
+    for (var index in indexes.toList()..sort((a, b) => b.compareTo(a))) {
+      try {
+        deleteAt(index, notify: notify);
+      } catch (e) {
+        // Ignore errors
+      }
+    }
+    return;
+  }
+
+  @override
   Future<int> clear({bool notify = true}) async {
     checkOpen();
 
@@ -266,6 +281,13 @@ class _NullBoxBase<E> implements BoxBase<E> {
   @override
   Never deleteAt(
     int index, {
+    bool notify = true,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Never deleteAllAt(
+    Iterable<int> indexes, {
     bool notify = true,
   }) =>
       throw UnimplementedError();

--- a/hive/lib/src/box/box_impl.dart
+++ b/hive/lib/src/box/box_impl.dart
@@ -82,6 +82,21 @@ class BoxImpl<E> extends BoxBaseImpl<E> implements Box<E> {
     return _writeFrames(frames, notify: notify);
   }
 
+  @override
+  Future<void> deleteAllAt(Iterable<int> indexes, {bool notify = true}) {
+    var frames = <Frame>[];
+    for (var index in indexes) {
+      try {
+        var frame = (keystore.frames as List<Frame>)[index];
+        frames.add(Frame.deleted(frame.key));
+      } catch (e) {
+        // Ignore error (index doesn't exist)
+      }
+    }
+
+    return _writeFrames(frames, notify: notify);
+  }
+
   Future<void> _writeFrames(
     List<Frame> frames, {
     bool notify = true,

--- a/hive/lib/src/box/lazy_box_impl.dart
+++ b/hive/lib/src/box/lazy_box_impl.dart
@@ -107,6 +107,36 @@ class LazyBoxImpl<E> extends BoxBaseImpl<E> implements LazyBox<E> {
   }
 
   @override
+  Future<void> deleteAllAt(
+    Iterable<int> indexes, {
+    bool notify = true,
+  }) async {
+    checkOpen();
+
+    var frames = <Frame>[];
+    for (var index in indexes) {
+      try {
+        var frame = (keystore.frames as List<Frame>)[index];
+        frames.add(Frame.deleted(frame.key));
+      } catch (e) {
+        // Ignore errors (index doesn't exist)
+      }
+    }
+
+    if (frames.isEmpty) return;
+    await backend.writeFrames(frames);
+
+    for (var frame in frames) {
+      keystore.insert(
+        frame,
+        notify: notify,
+      );
+    }
+
+    await performCompactionIfNeeded();
+  }
+
+  @override
   Future<void> flush() async {
     await backend.flush();
   }

--- a/hive/test/tests/box/box_base_test.dart
+++ b/hive/test/tests/box/box_base_test.dart
@@ -293,42 +293,6 @@ void main() {
       });
     });
 
-    group('.deleteAllAt()', () {
-      test('deletes frames at given indexes', () async {
-        var box = _openBoxBaseMock();
-        returnFutureVoid(when(() => box.delete('a')));
-        returnFutureVoid(when(() => box.delete('b')));
-
-        box.keystore.insert(Frame.lazy('a'));
-        box.keystore.insert(Frame.lazy('b'));
-        box.keystore.insert(Frame.lazy('c'));
-
-        await box.deleteAllAt([0, 1]);
-        verify(() => box.delete('a'));
-        verify(() => box.delete('b'));
-      });
-
-      test('does nothing for empty indexes', () async {
-        var box = _openBoxBaseMock();
-        box.keystore.insert(Frame.lazy('a'));
-        box.keystore.insert(Frame.lazy('b'));
-        box.keystore.insert(Frame.lazy('c'));
-
-        await box.deleteAllAt([]);
-        verifyNever(() => box.deleteAll(any()));
-      });
-
-      test('does nothing for invalid indexes', () async {
-        var box = _openBoxBaseMock();
-        box.keystore.insert(Frame.lazy('a'));
-        box.keystore.insert(Frame.lazy('b'));
-        box.keystore.insert(Frame.lazy('c'));
-
-        await box.deleteAllAt([-1, 3]);
-        verifyNever(() => box.deleteAll(any()));
-      });
-    });
-
     group('.clear()', () {
       test('clears keystore and backend', () async {
         var backend = MockStorageBackend();

--- a/hive/test/tests/box/box_base_test.dart
+++ b/hive/test/tests/box/box_base_test.dart
@@ -293,6 +293,42 @@ void main() {
       });
     });
 
+    group('.deleteAllAt()', () {
+      test('deletes frames at given indexes', () async {
+        var box = _openBoxBaseMock();
+        returnFutureVoid(when(() => box.delete('a')));
+        returnFutureVoid(when(() => box.delete('b')));
+
+        box.keystore.insert(Frame.lazy('a'));
+        box.keystore.insert(Frame.lazy('b'));
+        box.keystore.insert(Frame.lazy('c'));
+
+        await box.deleteAllAt([0, 1]);
+        verify(() => box.delete('a'));
+        verify(() => box.delete('b'));
+      });
+
+      test('does nothing for empty indexes', () async {
+        var box = _openBoxBaseMock();
+        box.keystore.insert(Frame.lazy('a'));
+        box.keystore.insert(Frame.lazy('b'));
+        box.keystore.insert(Frame.lazy('c'));
+
+        await box.deleteAllAt([]);
+        verifyNever(() => box.deleteAll(any()));
+      });
+
+      test('does nothing for invalid indexes', () async {
+        var box = _openBoxBaseMock();
+        box.keystore.insert(Frame.lazy('a'));
+        box.keystore.insert(Frame.lazy('b'));
+        box.keystore.insert(Frame.lazy('c'));
+
+        await box.deleteAllAt([-1, 3]);
+        verifyNever(() => box.deleteAll(any()));
+      });
+    });
+
     group('.clear()', () {
       test('clears keystore and backend', () async {
         var backend = MockStorageBackend();


### PR DESCRIPTION
As suggested in [this](https://stackoverflow.com/questions/76823646/deleting-multiple-items-by-index-in-flutter-hive) StackOverflow thread, I've added a function that allows multiple elements in a box to be deleted at the same time based off of a list of indices.

I've also written tests for the new function.