### PR TITLE
Update initialization in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Hive needs a place to call home. Using `path_provider` we can find a valid direc
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final dir = await getApplicationDocumentsDirectory();
-  Hive.defaultDirectory = dir.path;
+  Hive.init(dir.path);
 
   // ...
 }


### PR DESCRIPTION
The README.md file shows the old way of initializing the Hive storage setting the default directory path. This PR fixes so that it uses the updated `init` method to initialize Hive.