### PR TITLE
Migrate Hive v2 to support Flutter web WASM

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,14 +13,14 @@ jobs:
       image:  google/dart:latest
     
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Collect coverage
       run: |
         dart pub get
         dart pub global activate test_coverage
         dart pub global run test_coverage --exclude "**/js/**"
       working-directory: hive
-    - uses: codecov/codecov-action@v1.0.0
+    - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: hive/coverage/lcov.info

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,9 +16,9 @@ jobs:
     - uses: actions/checkout@v1
     - name: Collect coverage
       run: |
-        pub get
-        pub global activate test_coverage
-        pub global run test_coverage --exclude "**/js/**"
+        dart pub get
+        dart pub global activate test_coverage
+        dart pub global run test_coverage --exclude "**/js/**"
       working-directory: hive
     - uses: codecov/codecov-action@v1.0.0
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - test-platform: chrome
             compiler: dart2js
           - test-platform: chrome
+            dart-channel: 3.4.0 # The test package requires 3.4.0 for WASM tests
             compiler: dart2wasm
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,14 @@ jobs:
     strategy:
       matrix:
         test-platform: [vm, chrome]
-        dart-channel: ["2.12.0", "2.13.0", "2.14.0"]
+        dart-channel: ["3.4.0"]
+        include:
+          - test-platform: vm
+            compiler: kernel
+          - test-platform: chrome
+            compiler: dart2js
+          - test-platform: chrome
+            compiler: dart2wasm
     steps:
       - uses: actions/checkout@v1
       - uses: dart-lang/setup-dart@v1
@@ -18,7 +25,7 @@ jobs:
         run: pub get
         working-directory: hive
       - name: Run tests
-        run: pub run test -p ${{ matrix.test-platform }}
+        run: pub run test -p ${{ matrix.test-platform }} -c ${{ matrix.compiler }}
         working-directory: hive
 
   test-hive-flutter:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,13 @@ jobs:
     strategy:
       matrix:
         test-platform: [vm, chrome]
-        dart-channel: ["3.3.0"]
+        dart-channel: ["3.4.0"]
         include:
           - test-platform: vm
             compiler: kernel
           - test-platform: chrome
             compiler: dart2js
           - test-platform: chrome
-            dart-channel: 3.4.0 # The test package requires 3.4.0 for WASM tests
             compiler: dart2wasm
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dart-channel: ["3.4.0"]
         include:
           - test-platform: vm
             compiler: kernel
@@ -20,7 +19,7 @@ jobs:
       - uses: browser-actions/setup-chrome@v1
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: ${{ matrix.dart-channel }}
+          sdk: 3.4.0
       - name: Install dependencies
         run: dart pub get
         working-directory: hive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         test-platform: [vm, chrome]
-        dart-channel: ["3.4.0"]
+        dart-channel: ["3.3.0"]
         include:
           - test-platform: vm
             compiler: kernel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dart-channel: ["2.12.0", "2.13.0"]
+        dart-channel: ["3.3.0"]
     steps:
       - uses: actions/checkout@v1
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           sdk: ${{ matrix.dart-channel }}
       - name: Install dependencies
-        run: pub get
+        run: dart pub get
         working-directory: hive
       - name: Run tests
-        run: pub run test -p ${{ matrix.test-platform }} -c ${{ matrix.compiler }}
+        run: dart pub run test -p ${{ matrix.test-platform }} -c ${{ matrix.compiler }}
         working-directory: hive
 
   test-hive-flutter:
@@ -63,10 +63,10 @@ jobs:
         with:
           sdk: ${{ matrix.dart-channel }}
       - name: Install dependencies
-        run: pub get
+        run: dart pub get
         working-directory: hive_generator/example
       - name: Generate build_runner output
-        run: pub run build_runner build --delete-conflicting-outputs
+        run: dart pub run build_runner build --delete-conflicting-outputs
         working-directory: hive_generator/example
 
   check-score:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         run: dart pub get
         working-directory: hive
       - name: Run tests
-        run: dart pub run test -p ${{ matrix.test-platform }} -c ${{ matrix.compiler }}
+        run: dart test -p ${{ matrix.test-platform }} -c ${{ matrix.compiler }}
         working-directory: hive
 
   test-hive-flutter:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dart-channel: ["3.3.0"]
+        dart-channel: ["3.4.0"]
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
             compiler: dart2wasm
     steps:
       - uses: actions/checkout@v4
+      - uses: browser-actions/setup-chrome@v1
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ matrix.dart-channel }}
@@ -32,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-channel: [dev, beta, stable]
+        flutter-channel: [beta, stable]
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           - test-platform: chrome
             compiler: dart2wasm
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ matrix.dart-channel }}
@@ -34,11 +34,8 @@ jobs:
       matrix:
         flutter-channel: [dev, beta, stable]
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-java@v1
-        with:
-          java-version: "12.x"
-      - uses: subosito/flutter-action@v1
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
         with:
           channel: ${{ matrix.flutter-channel }}
       - name: Override dependency version
@@ -58,7 +55,7 @@ jobs:
       matrix:
         dart-channel: ["3.3.0"]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ matrix.dart-channel }}
@@ -75,9 +72,10 @@ jobs:
       matrix:
         package: [hive, hive_generator, hive_flutter]
     steps:
-      - uses: actions/checkout@v1
-      - uses: axel-op/dart-package-analyzer@v3
-        with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
-          relativePath: ${{ matrix.package }}
-          minAnnotationLevel: warning
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+      - run: |
+          cd ${{ matrix.package }}
+          flutter pub get
+          dart pub global activate pana
+          pana --no-warning --exit-code-threshold 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        test-platform: [vm, chrome]
         dart-channel: ["3.4.0"]
         include:
           - test-platform: vm

--- a/hive/example/pubspec.yaml
+++ b/hive/example/pubspec.yaml
@@ -8,7 +8,7 @@ dev_dependencies:
   build_runner: any
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: ^3.0.0
 
 dependency_overrides:
   hive:

--- a/hive/lib/hive.dart
+++ b/hive/lib/hive.dart
@@ -19,7 +19,7 @@ import 'package:hive/src/util/extensions.dart';
 import 'package:meta/meta.dart';
 
 export 'src/box_collection/box_collection_stub.dart'
-    if (dart.library.html) 'package:hive/src/box_collection/box_collection_indexed_db.dart'
+    if (dart.library.js_interop) 'package:hive/src/box_collection/box_collection_indexed_db.dart'
     if (dart.library.io) 'package:hive/src/box_collection/box_collection.dart';
 export 'src/object/hive_object.dart' show HiveObject, HiveObjectMixin;
 

--- a/hive/lib/src/backend/js/native/backend_manager.dart
+++ b/hive/lib/src/backend/js/native/backend_manager.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:js_interop';
 import 'package:hive/hive.dart';
 import 'package:hive/src/backend/js/native/storage_backend_js.dart';
+import 'package:hive/src/backend/js/native/utils.dart';
 import 'package:hive/src/backend/storage_backend.dart';
 import 'package:web/web.dart';
 
@@ -16,31 +17,28 @@ class BackendManager implements BackendManagerInterface {
     final databaseName = collection ?? name;
     final objectStoreName = collection == null ? 'box' : name;
 
-    var db = await openDatabase(
-      databaseName,
-      onUpgradeNeeded: (e) {
-        var db = e.target.result as IDBDatabase;
-        if (!db.objectStoreNames.contains(objectStoreName)) {
-          db.createObjectStore(objectStoreName);
-        }
-      },
-    );
+    final request = indexedDB!.open(databaseName, 1);
+    request.onupgradeneeded = (e) {
+      var db = e.target.result as IDBDatabase;
+      if (!db.objectStoreNames.contains(objectStoreName)) {
+        db.createObjectStore(objectStoreName);
+      }
+    }.toJS;
+    var db = await request.asFuture() as IDBDatabase;
 
     // in case the objectStore is not contained, re-open the db and
     // update version
     if (!db.objectStoreNames.contains(objectStoreName)) {
       print(
           'Creating objectStore $objectStoreName in database $databaseName...');
-      db = await openDatabase(
-        databaseName,
-        version: db.version + 1,
-        onUpgradeNeeded: (e) {
-          var db = e.target.result as IDBDatabase;
-          if (!db.objectStoreNames.contains(objectStoreName)) {
-            db.createObjectStore(objectStoreName);
-          }
-        },
-      );
+      final request = indexedDB!.open(databaseName, db.version + 1);
+      request.onupgradeneeded = (e) {
+        var db = e.target.result as IDBDatabase;
+        if (!db.objectStoreNames.contains(objectStoreName)) {
+          db.createObjectStore(objectStoreName);
+        }
+      }.toJS;
+      db = await request.asFuture() as IDBDatabase;
     }
 
     print('Got object store $objectStoreName in database $databaseName.');
@@ -58,16 +56,18 @@ class BackendManager implements BackendManagerInterface {
 
     // directly deleting the entire DB if a non-collection Box
     if (collection == null) {
-      await deleteDatabase(databaseName);
+      await indexedDB!.deleteDatabase(databaseName).asFuture();
     } else {
-      final db = await openDatabase(databaseName, onUpgradeNeeded: (e) {
+      final request = indexedDB!.open(databaseName, 1);
+      request.onupgradeneeded = (e) {
         var db = e.target.result as IDBDatabase;
         if (db.objectStoreNames.contains(objectStoreName)) {
           db.deleteObjectStore(objectStoreName);
         }
-      });
+      }.toJS;
+      final db = await request.asFuture();
       if (db.objectStoreNames.length == 0) {
-        await deleteDatabase(databaseName);
+        await indexedDB!.deleteDatabase(databaseName).asFuture();
       }
     }
   }
@@ -81,45 +81,24 @@ class BackendManager implements BackendManagerInterface {
     try {
       var _exists = true;
       if (collection == null) {
-        await openDatabase(databaseName, onUpgradeNeeded: (e) {
+        final request = indexedDB!.open(databaseName, 1);
+        request.onupgradeneeded = (e) {
           e.target.transaction!.abort();
           _exists = false;
-        });
+        }.toJS;
+        await request.asFuture();
       } else {
-        final db = await openDatabase(collection, onUpgradeNeeded: (e) {
+        final request = indexedDB!.open(collection, 1);
+        request.onupgradeneeded = (e) {
           var db = e.target.result as IDBDatabase;
           _exists = db.objectStoreNames.contains(objectStoreName);
-        });
+        }.toJS;
+        final db = await request.asFuture();
         _exists = db.objectStoreNames.contains(objectStoreName);
       }
       return _exists;
     } catch (error) {
       return false;
     }
-  }
-
-  Future<IDBDatabase> openDatabase(
-    String name, {
-    int version = 1,
-    void Function(dynamic event)? onUpgradeNeeded,
-  }) async {
-    final request = indexedDB!.open(name, version);
-    request.onupgradeneeded = onUpgradeNeeded?.toJS;
-
-    final completer = Completer<IDBDatabase>();
-    request.onsuccess = (e) {
-      completer.complete(e.target.result as IDBDatabase);
-    }.toJS;
-    return completer.future;
-  }
-
-  Future<void> deleteDatabase(String name) async {
-    final request = indexedDB!.deleteDatabase(name);
-    final completer = Completer();
-    request.onsuccess = (e) {
-      completer.complete();
-    }.toJS;
-    request.onerror = completer.completeError.toJS;
-    return completer.future;
   }
 }

--- a/hive/lib/src/backend/js/native/backend_manager.dart
+++ b/hive/lib/src/backend/js/native/backend_manager.dart
@@ -24,7 +24,7 @@ class BackendManager implements BackendManagerInterface {
         db.createObjectStore(objectStoreName);
       }
     }.toJS;
-    var db = await request.asFuture() as IDBDatabase;
+    var db = await request.asFuture<IDBDatabase>();
 
     // in case the objectStore is not contained, re-open the db and
     // update version
@@ -38,7 +38,7 @@ class BackendManager implements BackendManagerInterface {
           db.createObjectStore(objectStoreName);
         }
       }.toJS;
-      db = await request.asFuture() as IDBDatabase;
+      db = await request.asFuture<IDBDatabase>();
     }
 
     print('Got object store $objectStoreName in database $databaseName.');
@@ -65,7 +65,7 @@ class BackendManager implements BackendManagerInterface {
           db.deleteObjectStore(objectStoreName);
         }
       }.toJS;
-      final db = await request.asFuture() as IDBDatabase;
+      final db = await request.asFuture<IDBDatabase>();
       if (db.objectStoreNames.length == 0) {
         await indexedDB!.deleteDatabase(databaseName).asFuture();
       }
@@ -93,7 +93,7 @@ class BackendManager implements BackendManagerInterface {
           var db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
           _exists = db.objectStoreNames.contains(objectStoreName);
         }.toJS;
-        final db = await request.asFuture() as IDBDatabase;
+        final db = await request.asFuture<IDBDatabase>();
         _exists = db.objectStoreNames.contains(objectStoreName);
       }
       return _exists;

--- a/hive/lib/src/backend/js/native/backend_manager.dart
+++ b/hive/lib/src/backend/js/native/backend_manager.dart
@@ -65,7 +65,7 @@ class BackendManager implements BackendManagerInterface {
           db.deleteObjectStore(objectStoreName);
         }
       }.toJS;
-      final db = await request.asFuture();
+      final db = await request.asFuture() as IDBDatabase;
       if (db.objectStoreNames.length == 0) {
         await indexedDB!.deleteDatabase(databaseName).asFuture();
       }
@@ -93,7 +93,7 @@ class BackendManager implements BackendManagerInterface {
           var db = e.target.result as IDBDatabase;
           _exists = db.objectStoreNames.contains(objectStoreName);
         }.toJS;
-        final db = await request.asFuture();
+        final db = await request.asFuture() as IDBDatabase;
         _exists = db.objectStoreNames.contains(objectStoreName);
       }
       return _exists;

--- a/hive/lib/src/backend/js/native/backend_manager.dart
+++ b/hive/lib/src/backend/js/native/backend_manager.dart
@@ -1,16 +1,13 @@
 import 'dart:async';
-import 'dart:html';
-import 'dart:indexed_db';
-import 'dart:js' as js;
+import 'dart:js_interop';
 import 'package:hive/hive.dart';
 import 'package:hive/src/backend/js/native/storage_backend_js.dart';
 import 'package:hive/src/backend/storage_backend.dart';
+import 'package:web/web.dart';
 
 /// Opens IndexedDB databases
 class BackendManager implements BackendManagerInterface {
-  IdbFactory? get indexedDB => js.context.hasProperty('window')
-      ? window.indexedDB
-      : WorkerGlobalScope.instance.indexedDB;
+  IDBFactory? get indexedDB => window.self.indexedDB;
 
   @override
   Future<StorageBackend> open(String name, String? path, bool crashRecovery,
@@ -19,25 +16,27 @@ class BackendManager implements BackendManagerInterface {
     final databaseName = collection ?? name;
     final objectStoreName = collection == null ? 'box' : name;
 
-    var db =
-        await indexedDB!.open(databaseName, version: 1, onUpgradeNeeded: (e) {
-      var db = e.target.result as Database;
-      if (!(db.objectStoreNames ?? []).contains(objectStoreName)) {
-        db.createObjectStore(objectStoreName);
-      }
-    });
+    var db = await openDatabase(
+      databaseName,
+      onUpgradeNeeded: (e) {
+        var db = e.target.result as IDBDatabase;
+        if (!db.objectStoreNames.contains(objectStoreName)) {
+          db.createObjectStore(objectStoreName);
+        }
+      },
+    );
 
     // in case the objectStore is not contained, re-open the db and
     // update version
-    if (!(db.objectStoreNames ?? []).contains(objectStoreName)) {
+    if (!db.objectStoreNames.contains(objectStoreName)) {
       print(
           'Creating objectStore $objectStoreName in database $databaseName...');
-      db = await indexedDB!.open(
+      db = await openDatabase(
         databaseName,
-        version: (db.version ?? 1) + 1,
+        version: db.version + 1,
         onUpgradeNeeded: (e) {
-          var db = e.target.result as Database;
-          if (!(db.objectStoreNames ?? []).contains(objectStoreName)) {
+          var db = e.target.result as IDBDatabase;
+          if (!db.objectStoreNames.contains(objectStoreName)) {
             db.createObjectStore(objectStoreName);
           }
         },
@@ -59,17 +58,16 @@ class BackendManager implements BackendManagerInterface {
 
     // directly deleting the entire DB if a non-collection Box
     if (collection == null) {
-      await indexedDB!.deleteDatabase(databaseName);
+      await deleteDatabase(databaseName);
     } else {
-      final db =
-          await indexedDB!.open(databaseName, version: 1, onUpgradeNeeded: (e) {
-        var db = e.target.result as Database;
-        if ((db.objectStoreNames ?? []).contains(objectStoreName)) {
+      final db = await openDatabase(databaseName, onUpgradeNeeded: (e) {
+        var db = e.target.result as IDBDatabase;
+        if (db.objectStoreNames.contains(objectStoreName)) {
           db.deleteObjectStore(objectStoreName);
         }
       });
-      if ((db.objectStoreNames ?? []).isEmpty) {
-        indexedDB!.deleteDatabase(databaseName);
+      if (db.objectStoreNames.length == 0) {
+        await deleteDatabase(databaseName);
       }
     }
   }
@@ -83,21 +81,45 @@ class BackendManager implements BackendManagerInterface {
     try {
       var _exists = true;
       if (collection == null) {
-        await indexedDB!.open(databaseName, version: 1, onUpgradeNeeded: (e) {
+        await openDatabase(databaseName, onUpgradeNeeded: (e) {
           e.target.transaction!.abort();
           _exists = false;
         });
       } else {
-        final db =
-            await indexedDB!.open(collection, version: 1, onUpgradeNeeded: (e) {
-          var db = e.target.result as Database;
-          _exists = (db.objectStoreNames ?? []).contains(objectStoreName);
+        final db = await openDatabase(collection, onUpgradeNeeded: (e) {
+          var db = e.target.result as IDBDatabase;
+          _exists = db.objectStoreNames.contains(objectStoreName);
         });
-        _exists = (db.objectStoreNames ?? []).contains(objectStoreName);
+        _exists = db.objectStoreNames.contains(objectStoreName);
       }
       return _exists;
     } catch (error) {
       return false;
     }
+  }
+
+  Future<IDBDatabase> openDatabase(
+    String name, {
+    int version = 1,
+    void Function(dynamic event)? onUpgradeNeeded,
+  }) async {
+    final request = indexedDB!.open(name, version);
+    request.onupgradeneeded = onUpgradeNeeded?.toJS;
+
+    final completer = Completer<IDBDatabase>();
+    request.onsuccess = (e) {
+      completer.complete(e.target.result as IDBDatabase);
+    }.toJS;
+    return completer.future;
+  }
+
+  Future<void> deleteDatabase(String name) async {
+    final request = indexedDB!.deleteDatabase(name);
+    final completer = Completer();
+    request.onsuccess = (e) {
+      completer.complete();
+    }.toJS;
+    request.onerror = completer.completeError.toJS;
+    return completer.future;
   }
 }

--- a/hive/lib/src/backend/js/native/backend_manager.dart
+++ b/hive/lib/src/backend/js/native/backend_manager.dart
@@ -18,8 +18,8 @@ class BackendManager implements BackendManagerInterface {
     final objectStoreName = collection == null ? 'box' : name;
 
     final request = indexedDB!.open(databaseName, 1);
-    request.onupgradeneeded = (e) {
-      var db = e.target.result as IDBDatabase;
+    request.onupgradeneeded = (IDBVersionChangeEvent e) {
+      var db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
       if (!db.objectStoreNames.contains(objectStoreName)) {
         db.createObjectStore(objectStoreName);
       }
@@ -32,8 +32,8 @@ class BackendManager implements BackendManagerInterface {
       print(
           'Creating objectStore $objectStoreName in database $databaseName...');
       final request = indexedDB!.open(databaseName, db.version + 1);
-      request.onupgradeneeded = (e) {
-        var db = e.target.result as IDBDatabase;
+      request.onupgradeneeded = (IDBVersionChangeEvent  e) {
+        var db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
         if (!db.objectStoreNames.contains(objectStoreName)) {
           db.createObjectStore(objectStoreName);
         }
@@ -59,8 +59,8 @@ class BackendManager implements BackendManagerInterface {
       await indexedDB!.deleteDatabase(databaseName).asFuture();
     } else {
       final request = indexedDB!.open(databaseName, 1);
-      request.onupgradeneeded = (e) {
-        var db = e.target.result as IDBDatabase;
+      request.onupgradeneeded = (IDBVersionChangeEvent  e) {
+        var db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
         if (db.objectStoreNames.contains(objectStoreName)) {
           db.deleteObjectStore(objectStoreName);
         }
@@ -82,15 +82,15 @@ class BackendManager implements BackendManagerInterface {
       var _exists = true;
       if (collection == null) {
         final request = indexedDB!.open(databaseName, 1);
-        request.onupgradeneeded = (e) {
-          e.target.transaction!.abort();
+        request.onupgradeneeded = (IDBVersionChangeEvent e) {
+          (e.target as IDBOpenDBRequest).transaction!.abort();
           _exists = false;
         }.toJS;
         await request.asFuture();
       } else {
         final request = indexedDB!.open(collection, 1);
-        request.onupgradeneeded = (e) {
-          var db = e.target.result as IDBDatabase;
+        request.onupgradeneeded = (IDBVersionChangeEvent e) {
+          var db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
           _exists = db.objectStoreNames.contains(objectStoreName);
         }.toJS;
         final db = await request.asFuture() as IDBDatabase;

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -101,12 +101,8 @@ class StorageBackendJs extends StorageBackend {
       return value.toDart;
     } else if (value is JSString) {
       return value.toDart;
-    } else if (value is JSArray<JSNumber>) {
-      return value.toDart.map((e) => e.toDartDouble).toList();
-    } else if (value is JSArray<JSBoolean>) {
-      return value.toDart.map((e) => e.toDart).toList();
-    } else if (value is JSArray<JSString>) {
-      return value.toDart.map((e) => e.toDart).toList();
+    } else if (value is JSArray) {
+      return value.toDart;
     }
 
     return null;

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -175,7 +175,7 @@ class StorageBackendJs extends StorageBackend {
   Future<Object?> readValue(Frame frame) async {
     final value =
         await getStore(false).get(_frameKeyToJS(frame.key)).asFuture();
-    return decodeValue(value as JSArrayBuffer);
+    return decodeValue(value);
   }
 
   @override

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -41,8 +41,9 @@ class StorageBackendJs extends StorageBackend {
 
   /// Not part of public API
   @visibleForTesting
-  JSAny? encodeValue(Frame frame) {
-    var value = frame.value;
+  JSAny? encodeValue(Frame frame) => _encodeValue(frame.value);
+
+  JSAny? _encodeValue(Object? value) {
     if (_cipher == null) {
       if (value == null) {
         return null;
@@ -56,12 +57,11 @@ class StorageBackendJs extends StorageBackend {
         return value.toJS;
       } else if (value is String) {
         return value.toJS;
-      } else if (value is List<num>) {
-        return value.map((e) => e.toJS).toList().toJS;
-      } else if (value is List<bool>) {
-        return value.map((e) => e.toJS).toList().toJS;
-      } else if (value is List<String>) {
-        return value.map((e) => e.toJS).toList().toJS;
+      } else if (value is List<num> ||
+          value is List<bool> ||
+          value is List<String>) {
+        value as List;
+        return value.map(_encodeValue).toList().toJS;
       }
     }
 

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -127,8 +127,8 @@ class StorageBackendJs extends StorageBackend {
     var store = getStore(false);
 
     if (store.has('getAllKeys') && !cursor) {
-      final result = await getStore(false).getAllKeys(null).asFuture();
-      return (result as JSArray).toDart.map((e) {
+      final result = await getStore(false).getAllKeys(null).asFuture<JSArray>();
+      return result.toDart.map((e) {
         if (e.isA<JSNumber>()) {
           e as JSNumber;
           return e.toDartInt;
@@ -149,8 +149,8 @@ class StorageBackendJs extends StorageBackend {
     var store = getStore(false);
 
     if (store.has('getAll') && !cursor) {
-      final result = await store.getAll(null).asFuture();
-      return (result as JSArray).toDart.map(decodeValue);
+      final result = await store.getAll(null).asFuture<JSArray>();
+      return result.toDart.map(decodeValue);
     } else {
       final cursors = await store.getCursors();
       return cursors.map((e) => e.value).toList();
@@ -232,7 +232,7 @@ class StorageBackendJs extends StorageBackend {
           db.deleteObjectStore(objectStoreName);
         }
       }.toJS;
-      final db = request.asFuture() as IDBDatabase;
+      final db = await request.asFuture<IDBDatabase>();
       if (db.objectStoreNames.length == 0) {
         await indexDB.deleteDatabase(_db.name).asFuture();
       }

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -107,7 +107,18 @@ class StorageBackendJs extends StorageBackend {
       return value.toDart;
     } else if (value.isA<JSArray>()) {
       value as JSArray;
-      return value.toDart;
+      return value.toDart.map((e) {
+        if (e.isA<JSNumber>()) {
+          e as JSNumber;
+          return e.toDartDouble;
+        } else if (e.isA<JSBoolean>()) {
+          e as JSBoolean;
+          return e.toDart;
+        } else if (e.isA<JSString>()) {
+          e as JSString;
+          return e.toDart;
+        }
+      }).toList();
     }
 
     return null;

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -197,8 +197,8 @@ class StorageBackendJs extends StorageBackend {
       await indexDB.deleteDatabase(_db.name).asFuture();
     } else {
       final request = indexDB.open(_db.name, 1);
-      request.onupgradeneeded = (e) {
-        var db = e.target.result as IDBDatabase;
+      request.onupgradeneeded = (IDBVersionChangeEvent e) {
+        var db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
         if (db.objectStoreNames.contains(objectStoreName)) {
           db.deleteObjectStore(objectStoreName);
         }

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -261,7 +261,7 @@ class StorageBackendJs extends StorageBackend {
     } else if (key is String) {
       return key.toJS;
     } else {
-      throw HiveError('Invalid key type');
+      throw HiveError('Invalid key type: ${key.runtimeType}');
     }
   }
 }

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -77,7 +77,7 @@ class StorageBackendJs extends StorageBackend {
   /// Not part of public API
   @visibleForTesting
   Object? decodeValue(JSAny? value) {
-    if (value.instanceOfString('ArrayBuffer')) {
+    if (value.isA<JSArrayBuffer>()) {
       value as JSArrayBuffer;
       var bytes = Uint8List.view(value.toDart);
       if (_isEncoded(bytes)) {

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -112,7 +112,7 @@ class StorageBackendJs extends StorageBackend {
       final result = await getStore(false).getAllKeys(null).asFuture();
       return result;
     } else {
-      final cursors = await getCursors(store);
+      final cursors = await store.getCursors();
       return cursors.map((e) => e.key).toList();
     }
   }
@@ -126,28 +126,9 @@ class StorageBackendJs extends StorageBackend {
       final result = await store.getAll(null).asFuture();
       return (result as List).map(decodeValue);
     } else {
-      final cursors = await getCursors(store);
+      final cursors = await store.getCursors();
       return cursors.map((e) => e.value).toList();
     }
-  }
-
-  Future<List<IDBCursorWithValue>> getCursors(IDBObjectStore store) async {
-    final cursorRequest = store.openCursor();
-    final cursorCompleter = Completer<void>();
-    final cursors = <IDBCursorWithValue>[];
-    cursorRequest.onsuccess = (e) {
-      final cursor = e.target.result as IDBCursorWithValue?;
-      if (cursor == null) {
-        cursorCompleter.complete();
-        return;
-      }
-      cursors.add(cursor);
-    }.toJS;
-    cursorRequest.onerror = (e) {
-      cursorCompleter.completeError(cursorRequest.error!);
-    }.toJS;
-    await cursorCompleter.future;
-    return cursors;
   }
 
   @override

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -107,18 +107,7 @@ class StorageBackendJs extends StorageBackend {
       return value.toDart;
     } else if (value.isA<JSArray>()) {
       value as JSArray;
-      return value.toDart.map((e) {
-        if (e.isA<JSNumber>()) {
-          e as JSNumber;
-          return e.toDartDouble;
-        } else if (e.isA<JSBoolean>()) {
-          e as JSBoolean;
-          return e.toDart;
-        } else if (e.isA<JSString>()) {
-          e as JSString;
-          return e.toDart;
-        }
-      }).toList();
+      return value.toDart.map(decodeValue).toList();
     }
 
     return null;
@@ -139,17 +128,15 @@ class StorageBackendJs extends StorageBackend {
 
     if (store.has('getAllKeys') && !cursor) {
       final result = await getStore(false).getAllKeys(null).asFuture();
-      final keys = <Object?>[];
-      for (final key in (result as JSArray).toDart) {
-        if (key.isA<JSNumber>()) {
-          key as JSNumber;
-          keys.add(key.toDartInt);
-        } else if (key.isA<JSString>()) {
-          key as JSString;
-          keys.add(key.toDart);
+      return (result as JSArray).toDart.map((e) {
+        if (e.isA<JSNumber>()) {
+          e as JSNumber;
+          return e.toDartInt;
+        } else if (e.isA<JSString>()) {
+          e as JSString;
+          e.toDart;
         }
-      }
-      return keys;
+      }).toList();
     } else {
       final cursors = await store.getCursors();
       return cursors.map((e) => e.key).toList();

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -121,8 +121,7 @@ class StorageBackendJs extends StorageBackend {
         }
       }).toList();
     } else {
-      final items = await store.iterate();
-      return items.keys.map((e) => e.dartify()).toList();
+      return store.iterate().map((e) => e.key.dartify()).toList();
     }
   }
 
@@ -135,8 +134,7 @@ class StorageBackendJs extends StorageBackend {
       final result = await store.getAll(null).asFuture<JSArray>();
       return result.toDart.map(decodeValue);
     } else {
-      final items = await store.iterate();
-      return items.values.map((e) => e.dartify()).toList();
+      return store.iterate().map((e) => e.value.dartify()).toList();
     }
   }
 

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -138,8 +138,8 @@ class StorageBackendJs extends StorageBackend {
         }
       }).toList();
     } else {
-      final cursors = await store.getCursors();
-      return cursors.map((e) => e.key).toList();
+      final items = await store.iterate();
+      return items.keys.map((e) => e.dartify()).toList();
     }
   }
 
@@ -152,8 +152,8 @@ class StorageBackendJs extends StorageBackend {
       final result = await store.getAll(null).asFuture<JSArray>();
       return result.toDart.map(decodeValue);
     } else {
-      final cursors = await store.getCursors();
-      return cursors.map((e) => e.value).toList();
+      final items = await store.iterate();
+      return items.values.map((e) => e.dartify()).toList();
     }
   }
 

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -134,7 +134,7 @@ class StorageBackendJs extends StorageBackend {
           return e.toDartInt;
         } else if (e.isA<JSString>()) {
           e as JSString;
-          e.toDart;
+          return e.toDart;
         }
       }).toList();
     } else {

--- a/hive/lib/src/backend/js/native/utils.dart
+++ b/hive/lib/src/backend/js/native/utils.dart
@@ -4,10 +4,10 @@ import 'dart:js_interop';
 import 'package:web/web.dart';
 
 extension IDBRequestExtension on IDBRequest {
-  Future<JSAny?> asFuture() {
-    final completer = Completer<JSAny?>();
+  Future<T> asFuture<T extends JSAny?>() {
+    final completer = Completer<T>();
     onsuccess = (Event e) {
-      completer.complete(result);
+      completer.complete(result as T);
     }.toJS;
     onerror = (Event e) {
       completer.completeError(error!);

--- a/hive/lib/src/backend/js/native/utils.dart
+++ b/hive/lib/src/backend/js/native/utils.dart
@@ -17,22 +17,23 @@ extension IDBRequestExtension on IDBRequest {
 }
 
 extension IDBObjectStoreExtension on IDBObjectStore {
-  Future<List<IDBCursorWithValue>> getCursors() async {
-    final cursorRequest = openCursor();
-    final cursorCompleter = Completer<void>();
-    final cursors = <IDBCursorWithValue>[];
-    cursorRequest.onsuccess = (Event e) {
+  Future<Map<JSAny?, JSAny?>> iterate() async {
+    final request = openCursor();
+    final completer = Completer<void>();
+    final items = <JSAny?, JSAny?>{};
+    request.onsuccess = (Event e) {
       final cursor = (e.target as IDBRequest).result as IDBCursorWithValue?;
       if (cursor == null) {
-        cursorCompleter.complete();
+        completer.complete();
         return;
       }
-      cursors.add(cursor);
+      items[cursor.key] = cursor.value;
+      cursor.continue_();
     }.toJS;
-    cursorRequest.onerror = (Event e) {
-      cursorCompleter.completeError(cursorRequest.error!);
+    request.onerror = (Event e) {
+      completer.completeError(request.error!);
     }.toJS;
-    await cursorCompleter.future;
-    return cursors;
+    await completer.future;
+    return items;
   }
 }

--- a/hive/lib/src/backend/js/native/utils.dart
+++ b/hive/lib/src/backend/js/native/utils.dart
@@ -6,10 +6,10 @@ import 'package:web/web.dart';
 extension IDBRequestExtension on IDBRequest {
   Future<dynamic> asFuture() {
     final completer = Completer<dynamic>();
-    onsuccess = (e) {
+    onsuccess = (Event e) {
       completer.complete(result);
     }.toJS;
-    onerror = (e) {
+    onerror = (Event e) {
       completer.completeError(error!);
     }.toJS;
     return completer.future;
@@ -21,15 +21,15 @@ extension IDBObjectStoreExtension on IDBObjectStore {
     final cursorRequest = openCursor();
     final cursorCompleter = Completer<void>();
     final cursors = <IDBCursorWithValue>[];
-    cursorRequest.onsuccess = (e) {
-      final cursor = e.target.result as IDBCursorWithValue?;
+    cursorRequest.onsuccess = (Event e) {
+      final cursor = (e.target as IDBRequest).result as IDBCursorWithValue?;
       if (cursor == null) {
         cursorCompleter.complete();
         return;
       }
       cursors.add(cursor);
     }.toJS;
-    cursorRequest.onerror = (e) {
+    cursorRequest.onerror = (Event e) {
       cursorCompleter.completeError(cursorRequest.error!);
     }.toJS;
     await cursorCompleter.future;

--- a/hive/lib/src/backend/js/native/utils.dart
+++ b/hive/lib/src/backend/js/native/utils.dart
@@ -4,8 +4,8 @@ import 'dart:js_interop';
 import 'package:web/web.dart';
 
 extension IDBRequestExtension on IDBRequest {
-  Future<dynamic> asFuture() {
-    final completer = Completer<dynamic>();
+  Future<JSAny?> asFuture() {
+    final completer = Completer<JSAny?>();
     onsuccess = (Event e) {
       completer.complete(result);
     }.toJS;

--- a/hive/lib/src/backend/js/native/utils.dart
+++ b/hive/lib/src/backend/js/native/utils.dart
@@ -15,3 +15,24 @@ extension IDBRequestExtension on IDBRequest {
     return completer.future;
   }
 }
+
+extension IDBObjectStoreExtension on IDBObjectStore {
+  Future<List<IDBCursorWithValue>> getCursors() async {
+    final cursorRequest = openCursor();
+    final cursorCompleter = Completer<void>();
+    final cursors = <IDBCursorWithValue>[];
+    cursorRequest.onsuccess = (e) {
+      final cursor = e.target.result as IDBCursorWithValue?;
+      if (cursor == null) {
+        cursorCompleter.complete();
+        return;
+      }
+      cursors.add(cursor);
+    }.toJS;
+    cursorRequest.onerror = (e) {
+      cursorCompleter.completeError(cursorRequest.error!);
+    }.toJS;
+    await cursorCompleter.future;
+    return cursors;
+  }
+}

--- a/hive/lib/src/backend/js/native/utils.dart
+++ b/hive/lib/src/backend/js/native/utils.dart
@@ -1,0 +1,17 @@
+import 'dart:async';
+import 'dart:js_interop';
+
+import 'package:web/web.dart';
+
+extension IDBRequestExtension on IDBRequest {
+  Future<dynamic> asFuture() {
+    final completer = Completer<dynamic>();
+    onsuccess = (e) {
+      completer.complete(result);
+    }.toJS;
+    onerror = (e) {
+      completer.completeError(error!);
+    }.toJS;
+    return completer.future;
+  }
+}

--- a/hive/lib/src/backend/storage_backend.dart
+++ b/hive/lib/src/backend/storage_backend.dart
@@ -6,7 +6,7 @@ import 'package:hive/src/box/keystore.dart';
 
 export 'package:hive/src/backend/stub/backend_manager.dart'
     if (dart.library.io) 'package:hive/src/backend/vm/backend_manager.dart'
-    if (dart.library.html) 'package:hive/src/backend/js/backend_manager.dart';
+    if (dart.library.js_interop) 'package:hive/src/backend/js/backend_manager.dart';
 
 /// Abstract storage backend
 abstract class StorageBackend {

--- a/hive/lib/src/binary/frame.dart
+++ b/hive/lib/src/binary/frame.dart
@@ -3,10 +3,10 @@ import 'package:hive/hive.dart';
 /// Not part of public API
 class Frame {
   /// Not part of public API
-  final dynamic key;
+  final Object? key;
 
   /// Not part of public API
-  final dynamic value;
+  final Object? value;
 
   /// Not part of public API
   final bool deleted;

--- a/hive/lib/src/box_collection/box_collection_indexed_db.dart
+++ b/hive/lib/src/box_collection/box_collection_indexed_db.dart
@@ -121,6 +121,7 @@ class CollectionBox<V> implements implementation.CollectionBox<V> {
   CollectionBox(this.name, this.boxCollection) {
     if (!(V is String ||
         V is int ||
+        V is Object ||
         V is List<Object?> ||
         V is Map<String, Object?> ||
         V is double)) {

--- a/hive/lib/src/box_collection/box_collection_indexed_db.dart
+++ b/hive/lib/src/box_collection/box_collection_indexed_db.dart
@@ -18,7 +18,7 @@ class BoxCollection implements implementation.BoxCollection {
   static Future<BoxCollection> open(
     String name,
     Set<String> boxNames, {
-    dynamic path,
+    String? path,
     HiveCipher? key,
   }) async {
     final request = window.self.indexedDB.open(name, 1);
@@ -198,7 +198,7 @@ class CollectionBox<V> implements implementation.CollectionBox<V> {
 
     txn ??= boxCollection._db.transaction(name.toJS, 'readwrite');
     final store = txn.objectStore(name);
-    await store.put(val.toJSBox, key.toJS).asFuture();
+    await store.put(val.jsify(), key.toJS).asFuture();
     _cache[key] = val;
     _cachedKeys?.add(key);
     return;

--- a/hive/lib/src/box_collection/box_collection_indexed_db.dart
+++ b/hive/lib/src/box_collection/box_collection_indexed_db.dart
@@ -32,7 +32,7 @@ class BoxCollection implements implementation.BoxCollection {
         );
       }
     }.toJS;
-    final _db = await request.asFuture() as IDBDatabase;
+    final _db = await request.asFuture<IDBDatabase>();
     return BoxCollection(_db, boxNames);
   }
 
@@ -137,7 +137,7 @@ class CollectionBox<V> implements implementation.CollectionBox<V> {
     if (cachedKey != null) return cachedKey.toList();
     txn ??= boxCollection._db.transaction(name.toJS, 'readonly');
     final store = txn.objectStore(name);
-    final result = await store.getAllKeys(null).asFuture() as JSArray;
+    final result = await store.getAllKeys(null).asFuture<JSArray>();
     final List<String> keys =
         List.from(result.toDart.cast<JSString>().map((e) => e.toDart));
     _cachedKeys = keys.toSet();

--- a/hive/lib/src/box_collection/box_collection_indexed_db.dart
+++ b/hive/lib/src/box_collection/box_collection_indexed_db.dart
@@ -21,8 +21,7 @@ class BoxCollection implements implementation.BoxCollection {
     dynamic path,
     HiveCipher? key,
   }) async {
-    final factory = window.indexedDB;
-    final request = factory.open(name, 1);
+    final request = window.self.indexedDB.open(name, 1);
     request.onupgradeneeded = (IDBVersionChangeEvent event) {
       final _db = (event.target as IDBOpenDBRequest).result as IDBDatabase;
       for (final name in boxNames) {
@@ -101,14 +100,13 @@ class BoxCollection implements implementation.BoxCollection {
 
   @override
   Future<void> deleteFromDisk() async {
-    final factory = window.indexedDB;
     for (final box in _openBoxes) {
       box._cache.clear();
       box._cachedKeys = null;
     }
     _openBoxes.clear();
     _db.close();
-    factory.deleteDatabase(_db.name);
+    window.self.indexedDB.deleteDatabase(_db.name);
   }
 }
 

--- a/hive/lib/src/box_collection/box_collection_indexed_db.dart
+++ b/hive/lib/src/box_collection/box_collection_indexed_db.dart
@@ -139,7 +139,7 @@ class CollectionBox<V> implements implementation.CollectionBox<V> {
     final store = txn.objectStore(name);
     final result = await store.getAllKeys(null).asFuture() as JSArray;
     final List<String> keys =
-        List.from(result.toDart.map((e) => (e as JSString).toDart));
+        List.from(result.toDart.cast<JSString>().map((e) => e.toDart));
     _cachedKeys = keys.toSet();
     return keys;
   }

--- a/hive/lib/src/box_collection/box_collection_indexed_db.dart
+++ b/hive/lib/src/box_collection/box_collection_indexed_db.dart
@@ -23,8 +23,8 @@ class BoxCollection implements implementation.BoxCollection {
   }) async {
     final factory = window.indexedDB;
     final request = factory.open(name, 1);
-    request.onupgradeneeded = (event) {
-      final _db = event.target.result as IDBDatabase;
+    request.onupgradeneeded = (IDBVersionChangeEvent event) {
+      final _db = (event.target as IDBOpenDBRequest).result as IDBDatabase;
       for (final name in boxNames) {
         _db.createObjectStore(
           name,
@@ -90,7 +90,7 @@ class BoxCollection implements implementation.BoxCollection {
       fun(txn);
     }
     final completer = Completer<void>();
-    txn.oncomplete = (_) {
+    txn.oncomplete = (Event e) {
       completer.complete();
     }.toJS;
     return;

--- a/hive/lib/src/box_collection/box_collection_indexed_db.dart
+++ b/hive/lib/src/box_collection/box_collection_indexed_db.dart
@@ -148,8 +148,7 @@ class CollectionBox<V> implements implementation.CollectionBox<V> {
     txn ??= boxCollection._db.transaction(name.toJS, 'readonly');
     final store = txn.objectStore(name);
     final map = <String, V>{};
-    final items = await store.iterate();
-    for (final entry in items.entries) {
+    await for (final entry in store.iterate()) {
       map[(entry.key as JSString).toDart] = entry.value.dartify() as V;
     }
     return map;

--- a/hive/lib/src/box_collection/box_collection_indexed_db.dart
+++ b/hive/lib/src/box_collection/box_collection_indexed_db.dart
@@ -147,9 +147,9 @@ class CollectionBox<V> implements implementation.CollectionBox<V> {
     txn ??= boxCollection._db.transaction(name.toJS, 'readonly');
     final store = txn.objectStore(name);
     final map = <String, V>{};
-    final cursors = await store.getCursors();
-    for (final cursor in cursors) {
-      map[cursor.key as String] = cursor.value.dartify() as V;
+    final items = await store.iterate();
+    for (final entry in items.entries) {
+      map[(entry.key as JSString).toDart] = entry.value.dartify() as V;
     }
     return map;
   }

--- a/hive/lib/src/object/hive_collection_mixin.dart
+++ b/hive/lib/src/object/hive_collection_mixin.dart
@@ -1,7 +1,7 @@
 import 'package:hive/hive.dart';
 
 /// Implemetation of [HiveCollection].
-mixin HiveCollectionMixin<E extends HiveObjectMixin>
+abstract class HiveCollectionMixin<E extends HiveObjectMixin>
     implements HiveCollection<E> {
   @override
   Iterable<dynamic> get keys sync* {

--- a/hive/lib/src/object/hive_collection_mixin.dart
+++ b/hive/lib/src/object/hive_collection_mixin.dart
@@ -1,7 +1,7 @@
 import 'package:hive/hive.dart';
 
 /// Implemetation of [HiveCollection].
-abstract class HiveCollectionMixin<E extends HiveObjectMixin>
+mixin HiveCollectionMixin<E extends HiveObjectMixin>
     implements HiveCollection<E> {
   @override
   Iterable<dynamic> get keys sync* {

--- a/hive/lib/src/util/delegating_list_view_mixin.dart
+++ b/hive/lib/src/util/delegating_list_view_mixin.dart
@@ -1,7 +1,7 @@
 import 'package:meta/meta.dart';
 
 /// Not part of public API
-mixin DelegatingListViewMixin<E> implements List<E> {
+abstract class DelegatingListViewMixin<E> implements List<E> {
   /// Not part of public API
   @protected
   @visibleForTesting

--- a/hive/lib/src/util/delegating_list_view_mixin.dart
+++ b/hive/lib/src/util/delegating_list_view_mixin.dart
@@ -1,7 +1,7 @@
 import 'package:meta/meta.dart';
 
 /// Not part of public API
-abstract class DelegatingListViewMixin<E> implements List<E> {
+mixin DelegatingListViewMixin<E> implements List<E> {
   /// Not part of public API
   @protected
   @visibleForTesting

--- a/hive/pubspec.yaml
+++ b/hive/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/hivedb/hive/tree/master/hive
 documentation: https://docs.hivedb.dev/
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.4.0
 
 dependencies:
   meta: ^1.3.0

--- a/hive/pubspec.yaml
+++ b/hive/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/hivedb/hive/tree/master/hive
 documentation: https://docs.hivedb.dev/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ^3.4.0
 
 dependencies:
   meta: ^1.3.0

--- a/hive/pubspec.yaml
+++ b/hive/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/hivedb/hive/tree/master/hive
 documentation: https://docs.hivedb.dev/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   meta: ^1.3.0

--- a/hive/pubspec.yaml
+++ b/hive/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   meta: ^1.3.0
   crypto: ^3.0.0
+  web: ^0.5.1
 
 dev_dependencies:
   test: ^1.17.12

--- a/hive/pubspec.yaml
+++ b/hive/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/hivedb/hive/tree/master/hive
 documentation: https://docs.hivedb.dev/
 
 environment:
-  sdk: ^3.4.0
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   meta: ^1.3.0

--- a/hive/test/integration/integration.dart
+++ b/hive/test/integration/integration.dart
@@ -23,7 +23,7 @@ Future<HiveImpl> createHive() async {
 Future<BoxBase<T>> openBox<T>(bool lazy,
     {HiveInterface? hive, List<int>? encryptionKey}) async {
   hive ??= await createHive();
-  var id = Random().nextInt(99999999);
+  var id = Random.secure().nextInt(99999999);
   HiveCipher? cipher;
   if (encryptionKey != null) {
     cipher = HiveAesCipher(encryptionKey);

--- a/hive/test/tests/backend/js/backend_manager_test.dart
+++ b/hive/test/tests/backend/js/backend_manager_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 import 'package:web/web.dart';
 
 Future<IDBDatabase> _openDb() {
-  final request = window.indexedDB.open('testBox', 1);
+  final request = window.self.indexedDB.open('testBox', 1);
   request.onupgradeneeded = (IDBVersionChangeEvent e) {
     var db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
     if (!db.objectStoreNames.contains('box')) {

--- a/hive/test/tests/backend/js/backend_manager_test.dart
+++ b/hive/test/tests/backend/js/backend_manager_test.dart
@@ -9,8 +9,8 @@ import 'package:web/web.dart';
 
 Future<IDBDatabase> _openDb() async {
   final request = window.indexedDB.open('testBox', 1);
-  request.onupgradeneeded = (e) {
-    var db = e.target.result as IDBDatabase;
+  request.onupgradeneeded = (IDBVersionChangeEvent e) {
+    var db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
     if (!db.objectStoreNames.contains('box')) {
       db.createObjectStore('box');
     }

--- a/hive/test/tests/backend/js/backend_manager_test.dart
+++ b/hive/test/tests/backend/js/backend_manager_test.dart
@@ -1,18 +1,21 @@
 @TestOn('browser')
-import 'dart:html';
-import 'dart:indexed_db';
+
+import 'dart:js_interop';
 
 import 'package:hive/src/backend/js/backend_manager.dart';
+import 'package:hive/src/backend/js/native/utils.dart';
 import 'package:test/test.dart';
+import 'package:web/web.dart';
 
-Future<Database> _openDb() async {
-  return await window.indexedDB!.open('testBox', version: 1,
-      onUpgradeNeeded: (e) {
-    var db = e.target.result as Database;
-    if (!db.objectStoreNames!.contains('box')) {
+Future<IDBDatabase> _openDb() async {
+  final request = window.indexedDB.open('testBox', 1);
+  request.onupgradeneeded = (e) {
+    var db = e.target.result as IDBDatabase;
+    if (!db.objectStoreNames.contains('box')) {
       db.createObjectStore('box');
     }
-  });
+  }.toJS;
+  return await request.asFuture() as IDBDatabase;
 }
 
 void main() {

--- a/hive/test/tests/backend/js/backend_manager_test.dart
+++ b/hive/test/tests/backend/js/backend_manager_test.dart
@@ -7,7 +7,7 @@ import 'package:hive/src/backend/js/native/utils.dart';
 import 'package:test/test.dart';
 import 'package:web/web.dart';
 
-Future<IDBDatabase> _openDb() async {
+Future<IDBDatabase> _openDb() {
   final request = window.indexedDB.open('testBox', 1);
   request.onupgradeneeded = (IDBVersionChangeEvent e) {
     var db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
@@ -15,7 +15,7 @@ Future<IDBDatabase> _openDb() async {
       db.createObjectStore('box');
     }
   }.toJS;
-  return await request.asFuture() as IDBDatabase;
+  return request.asFuture<IDBDatabase>();
 }
 
 void main() {

--- a/hive/test/tests/backend/js/storage_backend_js_test.dart
+++ b/hive/test/tests/backend/js/storage_backend_js_test.dart
@@ -190,16 +190,12 @@ void main() async {
     });
 
     group('.getKeys()', () {
-      test(
-        'with cursor',
-        () async {
-          var db = await _getDbWith({'key1': 1, 'key2': 2, 'key3': 3});
-          var backend = _getBackend(db: db);
+      test('with cursor', () async {
+        var db = await _getDbWith({'key1': 1, 'key2': 2, 'key3': 3});
+        var backend = _getBackend(db: db);
 
-          expect(await backend.getKeys(cursor: true), ['key1', 'key2', 'key3']);
-        },
-        skip: 'Not working',
-      );
+        expect(await backend.getKeys(cursor: true), ['key1', 'key2', 'key3']);
+      });
 
       test('without cursor', () async {
         var db = await _getDbWith({'key1': 1, 'key2': 2, 'key3': 3});
@@ -210,16 +206,12 @@ void main() async {
     });
 
     group('.getValues()', () {
-      test(
-        'with cursor',
-        () async {
-          var db = await _getDbWith({'key1': 1, 'key2': null, 'key3': 3});
-          var backend = _getBackend(db: db);
+      test('with cursor', () async {
+        var db = await _getDbWith({'key1': 1, 'key2': null, 'key3': 3});
+        var backend = _getBackend(db: db);
 
-          expect(await backend.getValues(cursor: true), [1, null, 3]);
-        },
-        skip: 'Not working',
-      );
+        expect(await backend.getValues(cursor: true), [1, null, 3]);
+      });
 
       test('without cursor', () async {
         var db = await _getDbWith({'key1': 1, 'key2': null, 'key3': 3});

--- a/hive/test/tests/backend/js/storage_backend_js_test.dart
+++ b/hive/test/tests/backend/js/storage_backend_js_test.dart
@@ -58,12 +58,11 @@ JSAny? _toJS(Object? value) {
     return value.toJS;
   } else if (value is String) {
     return value.toJS;
-  } else if (value is List<num>) {
-    return value.map((e) => e.toJS).toList().toJS;
-  } else if (value is List<bool>) {
-    return value.map((e) => e.toJS).toList().toJS;
-  } else if (value is List<String>) {
-    return value.map((e) => e.toJS).toList().toJS;
+  } else if (value is List<num> ||
+      value is List<bool> ||
+      value is List<String>) {
+    value as List;
+    return value.map(_toJS).toList().toJS;
   } else {
     return null;
   }

--- a/hive/test/tests/backend/js/storage_backend_js_test.dart
+++ b/hive/test/tests/backend/js/storage_backend_js_test.dart
@@ -27,7 +27,7 @@ StorageBackendJs _getBackend({
 }
 
 Future<IDBDatabase> _openDb([String name = 'testBox']) async {
-  final request = window.indexedDB.open(name, 1);
+  final request = window.self.indexedDB.open(name, 1);
   request.onupgradeneeded = (IDBVersionChangeEvent e) {
     var db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
     if (!db.objectStoreNames.contains('box')) {

--- a/hive/test/tests/backend/js/storage_backend_js_test.dart
+++ b/hive/test/tests/backend/js/storage_backend_js_test.dart
@@ -95,10 +95,7 @@ void main() async {
               expect(encoded.toDart[j], expected.toDart[j]);
             }
           } else {
-            expect(
-              encoded.equals(expected).toDart,
-              isTrue,
-            );
+            expect(encoded.equals(expected).toDart, true);
           }
         }
 

--- a/hive/test/tests/backend/js/storage_backend_js_test.dart
+++ b/hive/test/tests/backend/js/storage_backend_js_test.dart
@@ -158,12 +158,16 @@ void main() async {
     });
 
     group('.getKeys()', () {
-      test('with cursor', () async {
-        var db = await _getDbWith({'key1': 1, 'key2': 2, 'key3': 3});
-        var backend = _getBackend(db: db);
+      test(
+        'with cursor',
+        () async {
+          var db = await _getDbWith({'key1': 1, 'key2': 2, 'key3': 3});
+          var backend = _getBackend(db: db);
 
-        expect(await backend.getKeys(cursor: true), ['key1', 'key2', 'key3']);
-      });
+          expect(await backend.getKeys(cursor: true), ['key1', 'key2', 'key3']);
+        },
+        skip: 'Not working',
+      );
 
       test('without cursor', () async {
         var db = await _getDbWith({'key1': 1, 'key2': 2, 'key3': 3});
@@ -174,12 +178,16 @@ void main() async {
     });
 
     group('.getValues()', () {
-      test('with cursor', () async {
-        var db = await _getDbWith({'key1': 1, 'key2': null, 'key3': 3});
-        var backend = _getBackend(db: db);
+      test(
+        'with cursor',
+        () async {
+          var db = await _getDbWith({'key1': 1, 'key2': null, 'key3': 3});
+          var backend = _getBackend(db: db);
 
-        expect(await backend.getValues(cursor: true), [1, null, 3]);
-      });
+          expect(await backend.getValues(cursor: true), [1, null, 3]);
+        },
+        skip: 'Not working',
+      );
 
       test('without cursor', () async {
         var db = await _getDbWith({'key1': 1, 'key2': null, 'key3': 3});

--- a/hive/test/tests/backend/js/storage_backend_js_test.dart
+++ b/hive/test/tests/backend/js/storage_backend_js_test.dart
@@ -34,7 +34,7 @@ Future<IDBDatabase> _openDb([String name = 'testBox']) async {
       db.createObjectStore('box');
     }
   }.toJS;
-  return await request.asFuture() as IDBDatabase;
+  return await request.asFuture<IDBDatabase>();
 }
 
 IDBObjectStore _getStore(IDBDatabase db) {

--- a/hive/test/tests/box_collection/box_collection_test.dart
+++ b/hive/test/tests/box_collection/box_collection_test.dart
@@ -1,0 +1,120 @@
+import 'package:hive/src/box_collection/box_collection.dart';
+import 'package:test/test.dart';
+
+Future<BoxCollection> _openCollection({bool withData = false}) async {
+  final collection =
+      await BoxCollection.open('MyFirstFluffyBox', {'cats', 'dogs'});
+  if (withData) {
+    final catsBox = await collection.openBox('cats');
+    await catsBox.put('fluffy', {'name': 'Fluffy', 'age': 4});
+    await catsBox.put('loki', {'name': 'Loki', 'age': 2});
+  }
+  return collection;
+}
+
+void main() {
+  group('BoxCollection', () {
+    test('.open', () async {
+      final collection = await _openCollection();
+      expect(collection.name, 'MyFirstFluffyBox');
+      expect(collection.boxNames, {'cats', 'dogs'});
+    });
+    test('.openBox', () async {
+      final collection = await _openCollection();
+      try {
+        await collection.openBox('rabbits');
+        throw Exception('BoxCollection.openBox did not throw');
+      } catch (e) {
+        // The test passed
+      }
+      final box1 = await collection.openBox('cats');
+      expect(box1.name, 'MyFirstFluffyBox_cats');
+    });
+
+    test('.transaction', () async {
+      final collection = await _openCollection();
+      final catsBox = await collection.openBox('cats');
+      await collection.transaction(() async {
+        await catsBox.put('fluffy', {'name': 'Fluffy', 'age': 4});
+        await catsBox.put('loki', {'name': 'Loki', 'age': 2});
+      });
+      expect(await catsBox.get('fluffy'), {'name': 'Fluffy', 'age': 4});
+      expect(await catsBox.get('loki'), {'name': 'Loki', 'age': 2});
+    });
+  });
+
+  group('CollectionBox', () {
+    test('.name', () async {
+      final collection = await _openCollection();
+      final box = await collection.openBox('cats');
+      expect(box.name, 'MyFirstFluffyBox_cats');
+    });
+
+    test('.boxCollection', () async {
+      final collection = await _openCollection();
+      final box = await collection.openBox('cats');
+      expect(box.boxCollection, collection);
+    });
+
+    test('.getAllKeys()', () async {
+      final collection = await _openCollection(withData: true);
+      final box = await collection.openBox('cats');
+      final keys = await box.getAllKeys();
+      expect(keys, ['fluffy', 'loki']);
+    });
+
+    test('.getAllValues()', () async {
+      final collection = await _openCollection(withData: true);
+      final box = await collection.openBox('cats');
+      final values = await box.getAllValues();
+      expect(values, {
+        'fluffy': {'name': 'Fluffy', 'age': 4},
+        'loki': {'name': 'Loki', 'age': 2}
+      });
+    });
+
+    test('.get()', () async {
+      final collection = await _openCollection(withData: true);
+      final box = await collection.openBox('cats');
+      expect(await box.get('fluffy'), {'name': 'Fluffy', 'age': 4});
+    });
+
+    test('.getAll()', () async {
+      final collection = await _openCollection(withData: true);
+      final box = await collection.openBox('cats');
+      final values = await box.getAll(['fluffy', 'loki']);
+      expect(values, [
+        {'name': 'Fluffy', 'age': 4},
+        {'name': 'Loki', 'age': 2}
+      ]);
+    });
+
+    test('.put()', () async {
+      final collection = await _openCollection();
+      final box = await collection.openBox('cats');
+      await box.put('fluffy', {'name': 'Fluffy', 'age': 4});
+      expect(await box.get('fluffy'), {'name': 'Fluffy', 'age': 4});
+    });
+
+    test('.delete()', () async {
+      final collection = await _openCollection(withData: true);
+      final box = await collection.openBox('cats');
+      await box.delete('fluffy');
+      expect(await box.get('fluffy'), null);
+    });
+
+    test('.deleteAll()', () async {
+      final collection = await _openCollection(withData: true);
+      final box = await collection.openBox('cats');
+      await box.deleteAll(['fluffy', 'loki']);
+      expect(await box.getAllKeys(), []);
+    });
+
+    test('.clear()', () async {
+      final collection = await _openCollection(withData: true);
+      final box = await collection.openBox('cats');
+      await box.clear();
+      expect(await box.getAllKeys(), []);
+    });
+  });
+}

--- a/hive/test/tests/frames.dart
+++ b/hive/test/tests/frames.dart
@@ -137,8 +137,10 @@ Frame lazyFrameWithLength(Frame frame, int length) {
 
 void expectFrame(Frame f1, Frame f2) {
   expect(f1.key, f2.key);
-  if (f1.value is double && f2.value is double) {
-    if (f1.value.isNaN as bool && f1.value.isNaN as bool) return;
+  final f1Value = f1.value;
+  final f2Value = f2.value;
+  if (f1Value is double && f2Value is double) {
+    if (f1Value.isNaN && f2Value.isNaN) return;
   }
   expect(f1.value, f2.value);
   expect(f1.length, f2.length);

--- a/hive/test/util/is_browser.dart
+++ b/hive/test/util/is_browser.dart
@@ -1,1 +1,1 @@
-export 'is_browser_vm.dart' if (dart.library.html) 'is_browser_js.dart';
+export 'is_browser_vm.dart' if (dart.library.js_interop) 'is_browser_js.dart';

--- a/hive_flutter/example/pubspec.yaml
+++ b/hive_flutter/example/pubspec.yaml
@@ -1,3 +1,3 @@
 name: example
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: ^3.0.0

--- a/hive_flutter/lib/hive_flutter.dart
+++ b/hive_flutter/lib/hive_flutter.dart
@@ -5,10 +5,10 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hive/hive.dart';
-import 'package:path/path.dart' if (dart.library.html) 'src/stub/path.dart'
-    as path_helper;
+import 'package:path/path.dart'
+    if (dart.library.js_interop) 'src/stub/path.dart' as path_helper;
 import 'package:path_provider/path_provider.dart'
-    if (dart.library.html) 'src/stub/path_provider.dart';
+    if (dart.library.js_interop) 'src/stub/path_provider.dart';
 
 export 'package:hive/hive.dart';
 

--- a/hive_flutter/pubspec.yaml
+++ b/hive_flutter/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/hivedb/hive/tree/master/hive_flutter
 documentation: https://docs.hivedb.dev/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   flutter:

--- a/hive_flutter/test/mocks.dart
+++ b/hive_flutter/test/mocks.dart
@@ -6,8 +6,8 @@ import 'package:mockito/annotations.dart';
 export 'mocks.mocks.dart';
 
 @GenerateMocks([], customMocks: [
-  MockSpec<BinaryReader>(returnNullOnMissingStub: true),
-  MockSpec<BinaryWriter>(returnNullOnMissingStub: true),
+  MockSpec<BinaryReader>(onMissingStub: OnMissingStub.returnDefault),
+  MockSpec<BinaryWriter>(onMissingStub: OnMissingStub.returnDefault),
 ])
 // ignore: prefer_typing_uninitialized_variables, unused_element
 var _mocks;

--- a/hive_generator/example/lib/types.g.dart
+++ b/hive_generator/example/lib/types.g.dart
@@ -6,50 +6,6 @@ part of 'types.dart';
 // TypeAdapterGenerator
 // **************************************************************************
 
-class Enum1Adapter extends TypeAdapter<Enum1> {
-  @override
-  final int typeId = 3;
-
-  @override
-  Enum1 read(BinaryReader reader) {
-    switch (reader.readByte()) {
-      case 0:
-        return Enum1.emumValue1;
-      case 1:
-        return Enum1.emumValue2;
-      case 2:
-        return Enum1.emumValue3;
-      default:
-        return Enum1.emumValue2;
-    }
-  }
-
-  @override
-  void write(BinaryWriter writer, Enum1 obj) {
-    switch (obj) {
-      case Enum1.emumValue1:
-        writer.writeByte(0);
-        break;
-      case Enum1.emumValue2:
-        writer.writeByte(1);
-        break;
-      case Enum1.emumValue3:
-        writer.writeByte(2);
-        break;
-    }
-  }
-
-  @override
-  int get hashCode => typeId.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is Enum1Adapter &&
-          runtimeType == other.runtimeType &&
-          typeId == other.typeId;
-}
-
 class Class1Adapter extends TypeAdapter<Class1> {
   @override
   final int typeId = 1;
@@ -107,10 +63,10 @@ class Class2Adapter extends TypeAdapter<Class2> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return Class2(
-      fields[0] == null ? 0 : fields[0] as int,
+      fields[0] == null ? 0 : (fields[0] as num).toInt(),
       fields[1] as String,
       (fields[6] as Map?)?.map((dynamic k, dynamic v) => MapEntry(
-          k as int,
+          (k as num).toInt(),
           (v as Map).map((dynamic k, dynamic v) =>
               MapEntry(k as String, (v as List).cast<Class1>())))),
     );
@@ -150,7 +106,7 @@ class EmptyClassAdapter extends TypeAdapter<EmptyClass> {
 
   @override
   void write(BinaryWriter writer, EmptyClass obj) {
-    writer..writeByte(0);
+    writer.writeByte(0);
   }
 
   @override
@@ -160,6 +116,50 @@ class EmptyClassAdapter extends TypeAdapter<EmptyClass> {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is EmptyClassAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}
+
+class Enum1Adapter extends TypeAdapter<Enum1> {
+  @override
+  final int typeId = 3;
+
+  @override
+  Enum1 read(BinaryReader reader) {
+    switch (reader.readByte()) {
+      case 0:
+        return Enum1.emumValue1;
+      case 1:
+        return Enum1.emumValue2;
+      case 2:
+        return Enum1.emumValue3;
+      default:
+        return Enum1.emumValue2;
+    }
+  }
+
+  @override
+  void write(BinaryWriter writer, Enum1 obj) {
+    switch (obj) {
+      case Enum1.emumValue1:
+        writer.writeByte(0);
+        break;
+      case Enum1.emumValue2:
+        writer.writeByte(1);
+        break;
+      case Enum1.emumValue3:
+        writer.writeByte(2);
+        break;
+    }
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Enum1Adapter &&
           runtimeType == other.runtimeType &&
           typeId == other.typeId;
 }

--- a/hive_generator/example/pubspec.yaml
+++ b/hive_generator/example/pubspec.yaml
@@ -6,7 +6,7 @@ dev_dependencies:
   hive_generator:
     path: ..
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: ^3.0.0
 dependency_overrides:
   hive:
     path: ../../hive

--- a/hive_generator/lib/src/builder.dart
+++ b/hive_generator/lib/src/builder.dart
@@ -12,7 +12,7 @@ class AdapterField {
 }
 
 abstract class Builder {
-  final ClassElement cls;
+  final InterfaceElement cls;
   final List<AdapterField> getters;
   final List<AdapterField> setters;
 

--- a/hive_generator/lib/src/class_builder.dart
+++ b/hive_generator/lib/src/class_builder.dart
@@ -7,13 +7,14 @@ import 'package:analyzer/dart/element/type.dart';
 import 'package:hive/hive.dart';
 import 'package:hive_generator/src/builder.dart';
 import 'package:hive_generator/src/helper.dart';
+import 'package:hive_generator/src/type_adapter_generator.dart';
 import 'package:source_gen/source_gen.dart';
 
 import 'type_helper.dart';
 
 class ClassBuilder extends Builder {
   ClassBuilder(
-    ClassElement cls,
+    InterfaceElement cls,
     List<AdapterField> getters,
     List<AdapterField> setters,
   ) : super(cls, getters, setters);
@@ -99,6 +100,10 @@ class ClassBuilder extends Builder {
       return '($variable as List$suffix)${_castIterable(type)}';
     } else if (mapChecker.isAssignableFromType(type)) {
       return '($variable as Map$suffix)${_castMap(type)}';
+    } else if (type.isDartCoreInt) {
+      return '($variable as num$suffix)$suffix.toInt()';
+    } else if (type.isDartCoreDouble) {
+      return '($variable as num$suffix)$suffix.toDouble()';
     } else {
       return '$variable as ${_displayString(type)}';
     }

--- a/hive_generator/lib/src/enum_builder.dart
+++ b/hive_generator/lib/src/enum_builder.dart
@@ -3,7 +3,7 @@ import 'package:hive_generator/src/builder.dart';
 import 'package:hive_generator/src/helper.dart';
 
 class EnumBuilder extends Builder {
-  EnumBuilder(ClassElement cls, List<AdapterField> getters)
+  EnumBuilder(InterfaceElement cls, List<AdapterField> getters)
       : super(cls, getters);
 
   @override

--- a/hive_generator/lib/src/helper.dart
+++ b/hive_generator/lib/src/helper.dart
@@ -32,13 +32,6 @@ bool isLibraryNNBD(Element element) {
   }
 }
 
-Iterable<ClassElement> getTypeAndAllSupertypes(ClassElement cls) {
-  var types = <ClassElement>{};
-  types.add(cls);
-  types.addAll(cls.allSupertypes.map((it) => it.element));
-  return types;
-}
-
 void check(bool condition, Object error) {
   if (!condition) {
     // ignore: only_throw_errors

--- a/hive_generator/lib/src/type_adapter_generator.dart
+++ b/hive_generator/lib/src/type_adapter_generator.dart
@@ -6,6 +6,7 @@ import 'package:hive_generator/src/class_builder.dart';
 import 'package:hive_generator/src/enum_builder.dart';
 import 'package:hive_generator/src/helper.dart';
 import 'package:source_gen/source_gen.dart';
+import 'package:source_helper/source_helper.dart';
 
 class TypeAdapterGenerator extends GeneratorForAnnotation<HiveType> {
   static String generateName(String typeName) {
@@ -36,7 +37,7 @@ class TypeAdapterGenerator extends GeneratorForAnnotation<HiveType> {
     var typeId = getTypeId(annotation);
 
     var adapterName = getAdapterName(cls.name, annotation);
-    var builder = cls.isEnum
+    var builder = cls.thisType.isEnum
         ? EnumBuilder(cls, getters)
         : ClassBuilder(cls, getters, setters);
 
@@ -68,14 +69,14 @@ class TypeAdapterGenerator extends GeneratorForAnnotation<HiveType> {
     ''';
   }
 
-  ClassElement getClass(Element element) {
+  InterfaceElement getClass(Element element) {
     check(element.kind == ElementKind.CLASS || element.kind == ElementKind.ENUM,
         'Only classes or enums are allowed to be annotated with @HiveType.');
 
-    return element as ClassElement;
+    return element as InterfaceElement;
   }
 
-  Set<String> getAllAccessorNames(ClassElement cls) {
+  Set<String> getAllAccessorNames(InterfaceElement cls) {
     var accessorNames = <String>{};
 
     var supertypes = cls.allSupertypes.map((it) => it.element);
@@ -94,7 +95,7 @@ class TypeAdapterGenerator extends GeneratorForAnnotation<HiveType> {
   }
 
   List<List<AdapterField>> getAccessors(
-      ClassElement cls, LibraryElement library) {
+      InterfaceElement cls, LibraryElement library) {
     var accessorNames = getAllAccessorNames(cls);
 
     var getters = <AdapterField>[];

--- a/hive_generator/pubspec.yaml
+++ b/hive_generator/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/hivedb/hive/tree/master/hive_generator
 documentation: https://docs.hivedb.dev/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   build: ^2.0.0

--- a/hive_generator/pubspec.yaml
+++ b/hive_generator/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   build: ^2.0.0
   source_gen: ^1.0.0
   hive: ^2.0.4
-  analyzer: ">=1.0.0 <5.0.0"
+  analyzer: ^6.0.0
   source_helper: ^1.1.0
 
 dev_dependencies:


### PR DESCRIPTION
Migrates Hive v2 to support Flutter web WASM since v3 and v4 are major changes (and not stable)

This _should not_ be merged into the main branch, but there isn't a better option right now. This should probalby be merged into a branch created off of the tag `v2.2.3` since that is the commit these changes are based on.

# IF YOU WANT TO USE THIS NOW
I have released the following packages to replace Hive in my projects. The intent is to keep these up to date with modern Dart/Flutter standards.

[hive_ce](https://pub.dev/packages/hive_ce)
[hive_ce_flutter](https://pub.dev/packages/hive_ce_flutter)
[hive_ce_generator](https://pub.dev/packages/hive_ce_generator)

If you do not want to use Hive Community Edition, you can use this PR directly:

```yaml
dependency_overrides:
  hive:
    git:
      url: https://github.com/Rexios80/hive
      ref: 4eb0dbc7807e7210831a2c71f056ac15c9e32e52
      path: hive
  hive_generator:
    git:
      url: https://github.com/Rexios80/hive
      ref: 4eb0dbc7807e7210831a2c71f056ac15c9e32e52
      path: hive_generator
```

Make sure to run the generator after updating

## Related issues
https://github.com/isar/hive/issues/1287
https://github.com/isar/isar/issues/1617
https://github.com/isar/isar/pull/1616