### PR TITLE
docs: Update README.md init doc code

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Hive needs a place to call home. Using `path_provider` we can find a valid direc
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final dir = await getApplicationDocumentsDirectory();
-  Hive.defaultDirectory = dir.path;
+  Hive.init(dir.path);
 
   // ...
 }


### PR DESCRIPTION
the default directory does not exist on the `Hive` API at least in version `2.2.3` would be helpful to update