### PR TITLE
Fix: Add Type parameter to resolve bug with generic types in mixin usage

### DIFF
--- a/lib/hive.dart
+++ b/lib/hive.dart
@@ -7,9 +7,9 @@ import 'dart:isolate'
     if (dart.library.html) 'package:hive/src/impl/isolate_stub.dart';
 
 import 'package:hive/src/impl/frame.dart';
-import 'package:isar/isar.dart';
+import 'package:isar_plus/isar_plus.dart';
 
-part 'src/impl/box_impl.dart';
-part 'src/impl/type_registry.dart';
 part 'src/box.dart';
 part 'src/hive.dart';
+part 'src/impl/box_impl.dart';
+part 'src/impl/type_registry.dart';

--- a/lib/src/hive.dart
+++ b/lib/src/hive.dart
@@ -38,8 +38,9 @@ class Hive {
   static void registerAdapter<T>(
     String typeName,
     T? Function(dynamic json) fromJson,
+    Type? type,
   ) {
-    _typeRegistry.register<T>(Isar.fastHash(typeName), fromJson);
+    _typeRegistry.register<T>(Isar.fastHash(typeName), fromJson, type);
   }
 
   /// Get or open the box with [name] in the given [directory]. If no directory

--- a/lib/src/hive.dart
+++ b/lib/src/hive.dart
@@ -37,9 +37,9 @@ class Hive {
   /// ```
   static void registerAdapter<T>(
     String typeName,
-    T? Function(dynamic json) fromJson,
+    T? Function(dynamic json) fromJson, [
     Type? type,
-  ) {
+  ]) {
     _typeRegistry.register<T>(Isar.fastHash(typeName), fromJson, type);
   }
 

--- a/lib/src/impl/frame.dart
+++ b/lib/src/impl/frame.dart
@@ -1,4 +1,4 @@
-import 'package:isar/isar.dart';
+import 'package:isar_plus/isar_plus.dart';
 
 part 'frame.g.dart';
 

--- a/lib/src/impl/type_registry.dart
+++ b/lib/src/impl/type_registry.dart
@@ -12,14 +12,18 @@ class _TypeRegistry {
   final Map<int, _TypeHandler<dynamic>> _registry = {};
   final Map<Type, _TypeHandler<dynamic>> _reverseRegistry = {..._builtinTypes};
 
-  void register<T>(int typeId, T? Function(dynamic json) fromJson) {
+  void register<T>(
+    int typeId,
+    T? Function(dynamic json) fromJson,
+    Type? type,
+  ) {
     if (T == dynamic) {
       throw ArgumentError('Cannot register dynamic type.');
     }
 
     final handler = _TypeHandler<T>(typeId, fromJson);
     _registry[typeId] = handler;
-    _reverseRegistry[T] = handler;
+    _reverseRegistry[type ?? T] = handler;
   }
 
   T fromJson<T>(int? typeId, dynamic json) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: ">=3.1.0 <4.0.0"
 
 dependencies:
-  isar_plus: ^1.0.3
+  isar_plus: ^1.0.4
   meta: ^1.9.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,11 +17,7 @@ environment:
   sdk: ">=3.1.0 <4.0.0"
 
 dependencies:
-  isar:
-    git:
-      url: https://github.com/ahmtydn/isar.git
-      ref: isar-dev
-      path: packages/isar
+  isar: ^4.0.0-dev.13
   meta: ^1.9.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: ">=3.1.0 <4.0.0"
 
 dependencies:
-  isar_plus: ^1.0.1
+  isar_plus: ^1.0.3
   meta: ^1.9.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: ">=3.1.0 <4.0.0"
 
 dependencies:
-  isar: ^4.0.0-dev.13
+  isar_plus: ^1.0.1
   meta: ^1.9.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,11 @@ environment:
   sdk: ">=3.1.0 <4.0.0"
 
 dependencies:
-  isar: ^4.0.0-dev.13
+  isar:
+    git:
+      url: https://github.com/ahmtydn/isar.git
+      ref: isar-dev
+      path: packages/isar
   meta: ^1.9.0
 
 dev_dependencies:

--- a/test/common.dart
+++ b/test/common.dart
@@ -4,7 +4,7 @@ import 'dart:math';
 
 import 'package:hive/hive.dart';
 import 'package:hive/src/impl/frame.dart';
-import 'package:isar/isar.dart';
+import 'package:isar_plus/isar_plus.dart';
 import 'package:test/test.dart';
 
 const _releases = 'https://github.com/isar/isar/releases/download/';


### PR DESCRIPTION
- Added Type parameter in adapter registration to fix issues with generic types when using mixins.
- This change addresses the bug where mixin-based models were not correctly recognized by the type registry.